### PR TITLE
[FIX] Celery import error and updated redis port

### DIFF
--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -4,14 +4,13 @@ from celery import Celery
 
 REDIS_URL = os.getenv("GOMOKU_REDIS_URL", "redis://redis:6379/0")
 
-celery_app = Celery(
+celery = Celery(
     "gomoku",
     broker=REDIS_URL,
     backend=REDIS_URL,
-    include=["services.tasks"],
 )
 
-celery_app.conf.update(
+celery.conf.update(
     task_serializer="json",
     result_serializer="json",
     accept_content=["json"],

--- a/backend/routes/games.py
+++ b/backend/routes/games.py
@@ -1,27 +1,23 @@
 from celery.result import AsyncResult
 from fastapi import APIRouter
 from pydantic import BaseModel
-
-from celery_app import celery_app
+from celery_app import celery
 from services.tasks import compute_ai_move_task
 
 router = APIRouter(prefix="/games")
 
-
 class MoveRequest(BaseModel):
     board: list
     current_player: int
-
 
 @router.post("/ai-move")
 def ai_move(req: MoveRequest):
     task = compute_ai_move_task.delay(req.model_dump())
     return {"task_id": task.id}
 
-
 @router.get("/ai-move/{task_id}")
 def ai_move_result(task_id: str):
-    result = AsyncResult(task_id, app=celery_app)
+    result = AsyncResult(task_id, app=celery)
     if result.state == "PENDING":
         return {"status": "pending"}
     if result.state == "STARTED":

--- a/backend/services/tasks.py
+++ b/backend/services/tasks.py
@@ -1,10 +1,8 @@
 import random
 import time
+from celery_app import celery
 
-from celery_app import celery_app
-
-
-@celery_app.task(name="compute_ai_move")
+@celery.task(name="compute_ai_move")
 def compute_ai_move_task(state: dict) -> dict:
     """
     Calls the Rust engine to compute the next move.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   backend:
     build: ./backend
+    working_dir: /app
     ports:
       - "8000:8000"
     environment:
@@ -15,7 +16,8 @@ services:
 
   celery-worker:
     build: ./backend
-    command: celery -A celery_app worker --loglevel=info
+    working_dir: /app
+    command: celery -A celery_app.celery worker --loglevel=info
     environment:
       - GOMOKU_REDIS_URL=redis://redis:6379/0
       - GOMOKU_ENGINE_BIN=/usr/local/bin/engine
@@ -28,7 +30,7 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379"
+      - "6380:6379"
 
   flower:
     image: mher/flower:2.0


### PR DESCRIPTION
Fix Celery import issue and adjust Redis port mapping

* Resolved Celery import error caused by circular dependency between `celery_app` and task modules
* Removed eager task loading (`include=["services.tasks"]`)
* Updated Redis port mapping to avoid conflict with host environment
* Exposed Redis on `6380` while keeping internal container port at `6379`

Closes #8 