### PR TITLE
[FEATURE] Engine: Add core game logic and win detection

### DIFF
--- a/engine/src/game.rs
+++ b/engine/src/game.rs
@@ -7,6 +7,7 @@ pub enum Player {
 }
 
 impl Player {
+    #[allow(dead_code)]
     pub fn opponent(self) -> Player {
         match self {
             Player::Black => Player::White,
@@ -22,17 +23,17 @@ impl Player {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Clone)]
 pub struct Move {
     pub x: usize,
     pub y: usize,
-    pub player: Player,
     pub captured: Vec<(usize, usize)> // coordinates of stones captured
 }
 
+#[allow(dead_code)]
 pub struct Game {
     pub board: Board,
-    pub current_player: Player,
     pub status: GameStatus,
     pub history: Vec<Move>,
     pub captures: (u8, u8), // (black, white)
@@ -44,15 +45,31 @@ pub enum GameStatus {
     Draw,
 }
 
+#[allow(dead_code)]
 impl Game {
     pub fn new() -> Self {
         Self {
             board: [[0; 19]; 19],
-            current_player: Player::Black,
             status: GameStatus::Ongoing,
-            history: Vec::new(),
+            history: Vec::new(), // The index of the history represents the move number, starting from 0 (player)
             captures: (0, 0),
         }
+    }
+
+    pub fn player_at(&self, move_index: usize) -> Player {
+        if move_index.is_multiple_of(2) {
+            Player::Black
+        } else {
+            Player::White
+        }
+    }
+
+    pub fn current_player(&self) -> Player {
+        self.player_at(self.history.len())
+    }
+
+    pub fn get_player_at(&self, index: usize) -> Player {
+        self.player_at(index)
     }
 
     pub fn play_move(&mut self, x: usize, y: usize) -> Result<(), String> {
@@ -68,21 +85,18 @@ impl Game {
             return Err("Game already finished".to_string());
         }
 
-        self.board[y][x] = self.current_player.to_u8();
+        self.board[y][x] = self.current_player().to_u8();
         self.history.push(Move {
             x,
             y,
-            player: self.current_player,
             captured: Vec::new(),
         });
 
         if self.check_win(x, y) {
             // mark game as finished
-            self.status = GameStatus::Win(self.current_player)
+            self.status = GameStatus::Win(self.current_player())
         } else if self.is_board_full() {
             self.status = GameStatus::Draw;
-        } else {
-            self.current_player = self.current_player.opponent();
         }
 
         Ok(())

--- a/engine/src/game.rs
+++ b/engine/src/game.rs
@@ -1,6 +1,6 @@
 pub type Board = [[u8; 19]; 19];
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Player {
     Black,
     White,
@@ -22,11 +22,12 @@ impl Player {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct Move {
     pub x: usize,
     pub y: usize,
     pub player: Player,
+    pub captured: Vec<(usize, usize)> // coordinates of stones captured
 }
 
 pub struct Game {
@@ -34,6 +35,7 @@ pub struct Game {
     pub current_player: Player,
     pub status: GameStatus,
     pub history: Vec<Move>,
+    pub captures: (u8, u8), // (black, white)
 }
 
 pub enum GameStatus {
@@ -49,6 +51,7 @@ impl Game {
             current_player: Player::Black,
             status: GameStatus::Ongoing,
             history: Vec::new(),
+            captures: (0, 0),
         }
     }
 
@@ -70,6 +73,7 @@ impl Game {
             x,
             y,
             player: self.current_player,
+            captured: Vec::new(),
         });
 
         if self.check_win(x, y) {
@@ -99,8 +103,48 @@ impl Game {
         }
     }
 
+    fn count_direction(&self, x: usize, y: usize, dx: isize, dy: isize) -> u32 {
+        let mut count = 0;
+        let player = self.board[y][x];
+
+        let mut cx = x as isize;
+        let mut cy = y as isize;
+
+        loop {
+            cx += dx;
+            cy += dy;
+
+            if cx < 0 || cy < 0 || cx >= 19 || cy >= 19 {
+                break;
+            }
+
+            if self.board[cy as usize][cx as usize] != player {
+                break;
+            }
+
+            count += 1;
+        }
+        count
+    }
+
     pub fn check_win(&self, x: usize, y: usize) -> bool {
-        //TODO:implement check win
+        let directions = [
+            (1, 0),  // horizontal
+            (0, 1),  // vertical
+            (1, 1),  // diagonal \
+            (1, -1), // diagonal /
+        ];
+
+        for (dx, dy) in directions {
+            // check the row length
+            let count = 1
+                + self.count_direction(x, y, dx, dy)
+                + self.count_direction(x, y, -dx, -dy);
+
+            if count >= 5 {
+                return true;
+            }
+        }
         false
 
     }

--- a/engine/src/game.rs
+++ b/engine/src/game.rs
@@ -22,10 +22,18 @@ impl Player {
     }
 }
 
+#[derive(Copy, Clone)]
+pub struct Move {
+    pub x: usize,
+    pub y: usize,
+    pub player: Player,
+}
+
 pub struct Game {
     pub board: Board,
     pub current_player: Player,
     pub status: GameStatus,
+    pub history: Vec<Move>,
 }
 
 pub enum GameStatus {
@@ -40,6 +48,7 @@ impl Game {
             board: [[0; 19]; 19],
             current_player: Player::Black,
             status: GameStatus::Ongoing,
+            history: Vec::new(),
         }
     }
 
@@ -57,6 +66,11 @@ impl Game {
         }
 
         self.board[y][x] = self.current_player.to_u8();
+        self.history.push(Move {
+            x,
+            y,
+            player: self.current_player,
+        });
 
         if self.check_win(x, y) {
             // mark game as finished

--- a/engine/src/game.rs
+++ b/engine/src/game.rs
@@ -1,15 +1,45 @@
 pub type Board = [[u8; 19]; 19];
 
+#[derive(Copy, Clone, PartialEq)]
+pub enum Player {
+    Black,
+    White,
+}
+
+impl Player {
+    pub fn opponent(self) -> Player {
+        match self {
+            Player::Black => Player::White,
+            Player::White => Player::Black,
+        }
+    }
+
+    pub fn to_u8(self) -> u8 {
+        match self {
+            Player::Black => 1,
+            Player::White => 2,
+        }
+    }
+}
+
 pub struct Game {
     pub board: Board,
-    pub current_player: u8,
+    pub current_player: Player,
+    pub status: GameStatus,
+}
+
+pub enum GameStatus {
+    Ongoing,
+    Win(Player),
+    Draw,
 }
 
 impl Game {
     pub fn new() -> Self {
         Self {
             board: [[0; 19]; 19],
-            current_player: 1,
+            current_player: Player::Black,
+            status: GameStatus::Ongoing,
         }
     }
 
@@ -22,9 +52,20 @@ impl Game {
             return Err("Cell already occupied".to_string());
         }
 
-        self.board[y][x] = self.current_player;
+        if !matches!(self.status, GameStatus::Ongoing) {
+            return Err("Game already finished".to_string());
+        }
 
-        self.current_player = if self.current_player == 1 { 2 } else { 1 };
+        self.board[y][x] = self.current_player.to_u8();
+
+        if self.check_win(x, y) {
+            // mark game as finished
+            self.status = GameStatus::Win(self.current_player)
+        } else if self.is_board_full() {
+            self.status = GameStatus::Draw;
+        } else {
+            self.current_player = self.current_player.opponent();
+        }
 
         Ok(())
     }
@@ -35,12 +76,29 @@ impl Game {
                 let symbol = match cell {
                     0 => ".",
                     1 => "X",
-                    2 => "0",
+                    2 => "O",
                     _ => "?",
                 };
                 print!("{} ", symbol);
             }
             println!();
         }
+    }
+
+    pub fn check_win(&self, x: usize, y: usize) -> bool {
+        //TODO:implement check win
+        false
+
+    }
+
+    pub fn is_board_full(&self) -> bool {
+        for row in self.board.iter() {
+            for cell in row.iter() {
+                if *cell == 0 {
+                    return false;
+                }
+            }
+        }
+        true
     }
 }

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1,6 +1,7 @@
 mod game;
 
 use game::Game;
+use game::GameStatus;
 
 fn main() {
     let mut game = Game::new();
@@ -8,5 +9,27 @@ fn main() {
     game.play_move(9, 9).unwrap();
     game.play_move(10, 9).unwrap();
 
+    game.play_move(0, 0).unwrap();
+    game.play_move(0, 1).unwrap();
+    game.play_move(1, 0).unwrap();
+    game.play_move(1, 1).unwrap();
+    game.play_move(2, 0).unwrap();
+    game.play_move(2, 1).unwrap();
+    game.play_move(3, 0).unwrap();
+    game.play_move(3, 1).unwrap();
+    game.play_move(4, 0).unwrap(); // should win
+
     game.print_board();
+
+    match game.status {
+        GameStatus::Win(player) => {
+            println!("Winner: {:?}", player);
+        }
+        GameStatus::Draw => {
+            println!("Draw");
+        }
+        GameStatus::Ongoing => {
+            println!("Game still ongoing");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

* Implemented core game structures (`Game`, `Player`, `GameStatus`)
* Added move handling (`play_move`) with validation
* Implemented win detection (5+ aligned stones)
* Added move history (`Vec<Move>`)

---

## Notes

* Win detection checks 4 directions from the last move
* Uses in-memory board (19x19)
* No advanced rules yet (captures, double-three)

---

## Test

Basic scenario confirms win:

```rust
game.play_move(0, 0);
game.play_move(0, 1);
game.play_move(1, 0);
game.play_move(1, 1);
game.play_move(2, 0);
game.play_move(2, 1);
game.play_move(3, 0);
game.play_move(3, 1);
game.play_move(4, 0);
```

Closes #5
