### PR TITLE
cd-ci: integrate rust doc into gh-pages branch

### DIFF
--- a/.github/workflows/engine-docs.yml
+++ b/.github/workflows/engine-docs.yml
@@ -1,0 +1,50 @@
+name: Engine docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "engine/**"
+      - ".github/workflows/engine-docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pages-engine
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: engine
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: engine
+
+      - name: Build documentation
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --no-deps --all-features
+
+      - name: Add root redirect to engine crate
+        run: echo '<meta http-equiv="refresh" content="0; url=engine/index.html">' > target/doc/index.html
+
+      - name: Deploy to gh-pages under /engine
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: engine/target/doc
+          destination_dir: engine
+          keep_files: true
+          commit_message: "docs(engine): deploy ${{ github.sha }}"


### PR DESCRIPTION
Integrates the docs into a `gh-pages` branch which will be deployed!