### PR TITLE
[FIX] Engine: Make move generation deterministic

### DIFF
--- a/engine/src/ai/search.rs
+++ b/engine/src/ai/search.rs
@@ -377,4 +377,64 @@ mod tests {
         assert_eq!(root.score, result.score);
         assert!(!root.children.is_empty());
     }
+
+    fn assert_deterministic(game: &Game, depth: u32) {
+        let mut g1 = game.clone();
+        let mut g2 = game.clone();
+
+        let r1 = best_move(&mut g1, depth);
+        let r2 = best_move(&mut g2, depth);
+
+        assert_eq!(r1.best_move, r2.best_move, "best move differs");
+        assert_eq!(r1.score, r2.score, "score differs");
+        assert_eq!(
+            r1.nodes_visited,
+            r2.nodes_visited,
+            "node count differs"
+        );
+    }
+
+    #[test]
+    fn deterministic_two_moves() {
+        let mut game = Game::new();
+
+        game.play_move(9, 9).unwrap();
+        game.play_move(10, 9).unwrap();
+
+        assert_deterministic(&game, 3);
+    }
+
+    #[test]
+    fn deterministic_block_position() {
+        let mut game = Game::new();
+
+        game.play_move(0, 9).unwrap();
+        game.play_move(0, 0).unwrap();
+        game.play_move(1, 9).unwrap();
+        game.play_move(0, 1).unwrap();
+        game.play_move(2, 9).unwrap();
+        game.play_move(0, 2).unwrap();
+        game.play_move(3, 9).unwrap();
+
+        assert_deterministic(&game, 3);
+    }
+
+    #[test]
+    fn deterministic_midgame() {
+        let mut game = Game::new();
+
+        let moves = [
+            (9, 9), (10, 9),
+            (9, 10), (10, 10),
+            (8, 9), (11, 9),
+            (8, 10), (11, 10),
+            (9, 8), (10, 8),
+        ];
+
+        for (x, y) in moves {
+            game.play_move(x, y).unwrap();
+        }
+
+        assert_deterministic(&game, 4);
+    }
 }

--- a/engine/src/board.rs
+++ b/engine/src/board.rs
@@ -22,6 +22,7 @@ const WORD_COUNT: usize = CELL_COUNT.div_ceil(64);
 /// Cells are flattened in row-major order: bit `y * BOARD_SIZE + x` is set
 /// when that cell holds a stone. Six `u64` words is enough for 19×19 = 361
 /// cells with room to spare.
+#[derive(Clone)]
 pub struct BitBoard {
     words: [u64; WORD_COUNT],
 }
@@ -90,6 +91,7 @@ impl BitBoard {
 /// The full game board: one [`BitBoard`] per player.
 ///
 /// Indexed `boards[player.idx()]`; black is index 0 and white is index 1.
+#[derive(Clone)]
 pub struct Board {
     boards: [BitBoard; 2],
 }

--- a/engine/src/game.rs
+++ b/engine/src/game.rs
@@ -631,6 +631,7 @@ impl Game {
                 moves.push((x, y));
             }
         }
+        moves.sort_unstable();
         moves
     }
 }

--- a/engine/src/game.rs
+++ b/engine/src/game.rs
@@ -155,6 +155,7 @@ impl std::fmt::Display for Move {
 /// All public fields are mutated in place by [`Game::play_move`] and
 /// [`Game::undo_move`]; nothing is reference-counted or cloned. The search
 /// uses make/unmake against a single `Game` rather than copying.
+#[derive(Clone)]
 pub struct Game {
     /// Stone placements.
     pub board: Board,
@@ -170,6 +171,7 @@ pub struct Game {
 
 /// Whether the game is still being played, has been won, or is drawn.
 #[allow(dead_code)]
+#[derive(Clone)]
 pub enum GameStatus {
     /// More moves are legal.
     Ongoing,


### PR DESCRIPTION
## Summary

Fix nondeterministic move ordering in alpha-beta search by sorting generated moves before traversal.

`generate_moves()` previously collected candidates through a `HashSet`, which does not guarantee iteration order. This caused identical searches to sometimes explore different trees and produce different `nodes_visited` counts despite returning the same best move and score.

The fix normalizes move ordering with:

```rust
moves.sort_unstable();
```

before returning generated moves.

Closes #38 