### PR TITLE
Refractor/replace xy pos

### DIFF
--- a/engine/src/ai/search.rs
+++ b/engine/src/ai/search.rs
@@ -30,6 +30,7 @@
 
 use crate::ai::eval::evaluate;
 use crate::game::{Game, GameStatus, Player};
+use crate::transpose::{Bound, TTEntry, TranspositionTable};
 
 /// Score returned for a decisive terminal position. Large enough to dominate
 /// any heuristic evaluation, small enough that `score + depth` can't overflow.
@@ -180,21 +181,32 @@ fn terminal_score(game: &Game, depth: u32) -> Option<i32> {
     }
 }
 
-/// Negamax with alpha-beta. Returns `(score, best_move_at_this_node)`.
+/// Negamax with alpha-beta pruning and transposition table support.
 ///
-/// `incoming_mv` is the move that led to this node, used only by the
-/// observer. It's `None` at the root.
+/// The transposition table stores previously searched positions keyed by
+/// Zobrist hash. Entries may contain:
 ///
-/// # Panics
+/// - [`Bound::Exact`] — exact minimax score for this position
+/// - [`Bound::Lower`] — lower bound (fail-high / beta cutoff)
+/// - [`Bound::Upper`] — upper bound (fail-low)
 ///
-/// Panics if [`Game::undo_move`] fails after a successful
-/// [`Game::play_move`]; that combination should be impossible and
-/// indicates a bug elsewhere.
+/// TT entries are reused to:
+///
+/// - return exact evaluations immediately
+/// - tighten the alpha-beta search window
+/// - improve move ordering by searching the previous best move first
+///
+/// Only entries searched to at least the current depth are trusted for
+/// pruning and ordering.
+///
+/// Returns `(score, best_move_at_this_node)`.
+#[allow(clippy::too_many_arguments)]
 fn negamax<O: Observer>(
     game: &mut Game,
     depth: u32,
     mut alpha: i32,
-    beta: i32,
+    mut beta: i32,
+    tt: &mut TranspositionTable,
     observer: &mut O,
     incoming_mv: Option<(usize, usize)>,
     nodes: &mut u64,
@@ -202,6 +214,36 @@ fn negamax<O: Observer>(
     *nodes += 1;
     let player = game.current_player();
     observer.enter(incoming_mv, player, depth, alpha, beta);
+
+    // Look in the transposition table, if the board has been generated
+    let original_alpha = alpha;
+    let original_beta = beta;
+    // Probe TT before searching children. Exact scores may terminate the
+    // search immediately; lower/upper bounds may tighten the search window.
+    let tt_entry = tt.get(game.hash);
+    if let Some(entry) = tt_entry {
+        if entry.depth >= depth as i32 {
+            match entry.flag {
+                Bound::Exact => {
+                    return (entry.score, entry.best_move);
+                }
+                Bound::Lower => {
+                    alpha = alpha.max(entry.score);
+                }
+                Bound::Upper => {
+                    beta = beta.min(entry.score);
+                    if alpha >= beta {
+                        observer.leave(entry.score, true);
+                        return (entry.score, entry.best_move);
+                    }
+                }
+            }
+            if alpha >= beta {
+                observer.leave(entry.score, true);
+                return (entry.score, entry.best_move);
+            }
+        }
+    }
 
     if let Some(score) = terminal_score(game, depth) {
         observer.leave(score, false);
@@ -214,13 +256,25 @@ fn negamax<O: Observer>(
         return (score, None);
     }
 
-    let moves = game.generate_moves();
+    let mut moves = game.generate_moves();
+
     if moves.is_empty() {
         // No legal continuations but game isn't flagged terminal — treat as
         // a quiet position and hand off to the evaluator.
         let score = evaluate(game);
         observer.leave(score, false);
         return (score, None);
+    }
+
+    if let Some(entry) = tt_entry {
+        if entry.depth >= depth as i32 {
+            if let Some(tt_mv) = entry.best_move {
+                if let Some(pos) = moves.iter().position(|&m| m == tt_mv) {
+                    // Search the previous best move first to maximize alpha-beta cutoffs.
+                    moves.swap(0, pos);
+                }
+            }
+        }
     }
 
     let mut best_score = i32::MIN + 1;
@@ -235,7 +289,7 @@ fn negamax<O: Observer>(
         }
 
         let (child_score, _) =
-            negamax(game, depth - 1, -beta, -alpha, observer, Some((x, y)), nodes);
+            negamax(game, depth - 1, -beta, -alpha, tt, observer, Some((x, y)), nodes);
         let score = -child_score;
 
         game.undo_move().expect("undo_move must succeed after a successful play_move");
@@ -253,6 +307,23 @@ fn negamax<O: Observer>(
         }
     }
 
+    // Classify the stored result relative to the original search window.
+    let flag = if best_score <= original_alpha {
+        Bound::Upper
+    } else if best_score >= original_beta {
+        Bound::Lower
+    } else {
+        Bound::Exact
+    };
+
+    tt.insert(game.hash, TTEntry {
+        key: game.hash,
+        depth: depth as i32,
+        score: best_score,
+        flag,
+        best_move: best_mv,
+    });
+
     observer.leave(best_score, pruned);
     (best_score, best_mv)
 }
@@ -268,7 +339,7 @@ fn negamax<O: Observer>(
 /// let result = best_move(&mut game, 4);
 /// assert_eq!(result.best_move, Some((9, 9))); // center on empty board
 /// ```
-pub fn best_move(game: &mut Game, depth: u32) -> SearchResult {
+pub fn best_move(game: &mut Game, depth: u32, tt: &mut TranspositionTable) -> SearchResult {
     let mut obs = NoopObserver;
     let mut nodes = 0u64;
     let (score, mv) = negamax(
@@ -276,6 +347,7 @@ pub fn best_move(game: &mut Game, depth: u32) -> SearchResult {
         depth,
         i32::MIN + 1,
         i32::MAX - 1,
+        tt,
         &mut obs,
         None,
         &mut nodes,
@@ -290,6 +362,7 @@ pub fn best_move(game: &mut Game, depth: u32) -> SearchResult {
 pub fn best_move_verbose(
     game: &mut Game,
     depth: u32,
+    tt: &mut TranspositionTable
 ) -> (SearchResult, Option<SearchNode>) {
     let mut obs = TreeObserver::new();
     let mut nodes = 0u64;
@@ -298,6 +371,7 @@ pub fn best_move_verbose(
         depth,
         i32::MIN + 1,
         i32::MAX - 1,
+        tt,
         &mut obs,
         None,
         &mut nodes,
@@ -314,7 +388,8 @@ mod tests {
     #[test]
     fn depth_zero_returns_eval_and_no_move() {
         let mut game = Game::new();
-        let result = best_move(&mut game, 0);
+        let mut tt = TranspositionTable::new(0);
+        let result = best_move(&mut game, 0, &mut tt);
         assert_eq!(result.best_move, None);
         assert_eq!(result.nodes_visited, 1);
     }
@@ -322,7 +397,8 @@ mod tests {
     #[test]
     fn returns_a_legal_move_on_empty_board() {
         let mut game = Game::new();
-        let result = best_move(&mut game, 1);
+        let mut tt = TranspositionTable::new(0);
+        let result = best_move(&mut game, 1, &mut tt);
         // On an empty board generate_moves yields exactly (9, 9).
         assert_eq!(result.best_move, Some((9, 9)));
     }
@@ -334,7 +410,8 @@ mod tests {
         game.play_move(10, 9).unwrap();
         let history_before = game.history.len();
 
-        let _ = best_move(&mut game, 2);
+        let mut tt = TranspositionTable::new(0);
+        let _ = best_move(&mut game, 2, &mut tt);
 
         assert_eq!(game.history.len(), history_before);
         assert_eq!(game.board.cell_at(9, 9), Some(Player::Black));
@@ -344,7 +421,7 @@ mod tests {
     #[test]
     fn blocks_an_immediate_win() {
         // Black has four stones in a row against the left edge: cols 0..=3 on
-        // row 9. The only way Black can extend to five is at (4, 9). If White
+        // row 9. The only way Black can extend to five is at (5, 9). If White
         // doesn't take it, Black wins on the next ply. White is on move.
         let mut game = Game::new();
         game.play_move(0, 9).unwrap();    // B
@@ -356,7 +433,8 @@ mod tests {
         game.play_move(3, 9).unwrap();    // B
         // White to move.
 
-        let result = best_move(&mut game, 2);
+        let mut tt = TranspositionTable::new(0);
+        let result = best_move(&mut game, 2, &mut tt);
         assert_eq!(
             result.best_move,
             Some((4, 9)),
@@ -369,12 +447,86 @@ mod tests {
         let mut game = Game::new();
         game.play_move(9, 9).unwrap();
 
-        let (result, tree) = best_move_verbose(&mut game, 2);
+        let mut tt = TranspositionTable::new(0);
+        let (result, tree) = best_move_verbose(&mut game, 2, &mut tt);
         let root = tree.expect("verbose mode should produce a root node");
 
         assert_eq!(root.depth_remaining, 2);
         assert_eq!(root.mv, None);
         assert_eq!(root.score, result.score);
         assert!(!root.children.is_empty());
+    }
+
+    #[test]
+    fn tt_does_not_change_best_move() {
+        let mut g1 = Game::new();
+        let mut g2 = g1.clone();
+
+        let mut tt_empty = TranspositionTable::new(0);
+        let mut tt = TranspositionTable::new(20);
+
+        let r1 = best_move(&mut g1, 4, &mut tt_empty); // no TT version
+        let r2 = best_move(&mut g2, 4, &mut tt);
+
+        assert_eq!(r1.best_move, r2.best_move);
+        assert_eq!(r1.score, r2.score);
+    }
+
+    #[test]
+    fn tt_reduces_node_count() {
+        let mut g1 = Game::new();
+        let mut g2 = g1.clone();
+
+        let mut tt_empty = TranspositionTable::new(0);
+        let mut tt = TranspositionTable::new(20);
+
+        let r1 = best_move(&mut g1, 6, &mut tt_empty);
+        let r2 = best_move(&mut g2, 6, &mut tt);
+
+        println!("no TT nodes: {}", r1.nodes_visited);
+        println!("TT nodes: {}", r2.nodes_visited);
+
+        assert!(r2.nodes_visited < r1.nodes_visited);
+    }
+
+    fn midgame_position() -> Game {
+        let mut g = Game::new();
+
+        let moves = [
+            (9, 9), (10, 9),
+            (9, 10), (10, 10),
+            (8, 9), (11, 9),
+            (8, 10), (11, 10),
+            (9, 8), (10, 8),
+        ];
+
+        for (x, y) in moves {
+            g.play_move(x, y).unwrap();
+        }
+
+        g
+    }
+
+    #[test]
+    fn tt_reduces_node_count_midgame() {
+        let mut g1 = midgame_position();
+        let mut g2 = g1.clone();
+
+        let mut tt_empty = TranspositionTable::new(0);
+        let mut tt = TranspositionTable::new(20);
+
+        let r1 = best_move(&mut g1, 4, &mut tt_empty);
+        let r2 = best_move(&mut g2, 4, &mut tt);
+
+        println!("no TT best move: {}, {}", r1.best_move.unwrap().0, r1.best_move.unwrap().1);
+        println!("TT best move: {}, {}", r2.best_move.unwrap().0, r2.best_move.unwrap().1);
+
+        assert_eq!(r1.best_move, r2.best_move, "best move differs with TT");
+        assert_eq!(r1.score, r2.score, "score differs with TT");
+
+        println!("no TT nodes: {}", r1.nodes_visited);
+        println!("TT nodes: {}", r2.nodes_visited);
+
+        assert!(r2.nodes_visited < r1.nodes_visited);
     }
 }

--- a/engine/src/ai/search.rs
+++ b/engine/src/ai/search.rs
@@ -22,7 +22,7 @@
 #![allow(dead_code)]
 
 use crate::ai::eval::evaluate;
-use crate::game::{Game, GameStatus, Player, Pos};
+use crate::game::{Game, GameStatus, Pos};
 use crate::transpose::{Bound, TTEntry, TranspositionTable};
 
 /// Score returned for a decisive terminal position. Large enough to dominate
@@ -83,28 +83,6 @@ fn negamax(
 ) -> (i32, Option<Pos>) {
     *nodes += 1;
 
-    let original_alpha = alpha;
-    let original_beta = beta;
-    let tt_entry = tt.get(game.hash());
-    if let Some(entry) = tt_entry {
-        if entry.depth >= depth as i32 {
-            match entry.flag {
-                Bound::Exact => {
-                    return (entry.score, entry.best_move);
-                }
-                Bound::Lower => {
-                    alpha = alpha.max(entry.score);
-                }
-                Bound::Upper => {
-                    beta = beta.min(entry.score);
-                }
-            }
-            if alpha >= beta {
-                return (entry.score, entry.best_move);
-            }
-        }
-    }
-
     // Look in the transposition table, if the board has been generated
     let original_alpha = alpha;
     let original_beta = beta;
@@ -122,14 +100,9 @@ fn negamax(
                 }
                 Bound::Upper => {
                     beta = beta.min(entry.score);
-                    if alpha >= beta {
-                        observer.leave(entry.score, true);
-                        return (entry.score, entry.best_move);
-                    }
                 }
             }
             if alpha >= beta {
-                observer.leave(entry.score, true);
                 return (entry.score, entry.best_move);
             }
         }
@@ -175,7 +148,6 @@ fn negamax(
 
     let mut best_score = i32::MIN + 1;
     let mut best_mv: Option<Pos> = None;
-    let mut pruned = false;
 
     for mv in moves {
         // generate_moves already filters illegal placements, but play_move
@@ -395,73 +367,10 @@ mod tests {
         let r1 = best_move(&mut g1, 6, &mut tt_empty);
         let r2 = best_move(&mut g2, 6, &mut tt);
 
-        assert!(r2.nodes_visited < r1.nodes_visited);
-    }
-
-    #[test]
-    fn tt_reduces_node_count_midgame() {
-        let mut g1 = midgame_position();
-        let mut g2 = g1.clone();
-
-        let mut tt_empty = TranspositionTable::new(0);
-        let mut tt = TranspositionTable::new(20);
-
-        let r1 = best_move(&mut g1, 4, &mut tt_empty);
-        let r2 = best_move(&mut g2, 4, &mut tt);
-
-        assert_eq!(r1.best_move, r2.best_move, "best move differs with TT");
-        assert_eq!(r1.score, r2.score, "score differs with TT");
-        assert!(r2.nodes_visited < r1.nodes_visited);
-    }
-
-    #[test]
-    fn tt_does_not_change_best_move() {
-        let mut g1 = Game::new();
-        let mut g2 = g1.clone();
-
-        let mut tt_empty = TranspositionTable::new(0);
-        let mut tt = TranspositionTable::new(20);
-
-        let r1 = best_move(&mut g1, 4, &mut tt_empty); // no TT version
-        let r2 = best_move(&mut g2, 4, &mut tt);
-
-        assert_eq!(r1.best_move, r2.best_move);
-        assert_eq!(r1.score, r2.score);
-    }
-
-    #[test]
-    fn tt_reduces_node_count() {
-        let mut g1 = Game::new();
-        let mut g2 = g1.clone();
-
-        let mut tt_empty = TranspositionTable::new(0);
-        let mut tt = TranspositionTable::new(20);
-
-        let r1 = best_move(&mut g1, 6, &mut tt_empty);
-        let r2 = best_move(&mut g2, 6, &mut tt);
-
         println!("no TT nodes: {}", r1.nodes_visited);
         println!("TT nodes: {}", r2.nodes_visited);
 
         assert!(r2.nodes_visited < r1.nodes_visited);
-    }
-
-    fn midgame_position() -> Game {
-        let mut g = Game::new();
-
-        let moves = [
-            (9, 9), (10, 9),
-            (9, 10), (10, 10),
-            (8, 9), (11, 9),
-            (8, 10), (11, 10),
-            (9, 8), (10, 8),
-        ];
-
-        for (x, y) in moves {
-            g.play_move(x, y).unwrap();
-        }
-
-        g
     }
 
     #[test]

--- a/engine/src/ai/search.rs
+++ b/engine/src/ai/search.rs
@@ -29,7 +29,7 @@
 #![allow(dead_code)]
 
 use crate::ai::eval::evaluate;
-use crate::game::{Game, GameStatus, Player};
+use crate::game::{Game, GameStatus, Player, Pos};
 use crate::transpose::{Bound, TTEntry, TranspositionTable};
 
 /// Score returned for a decisive terminal position. Large enough to dominate
@@ -40,7 +40,7 @@ pub const WIN_SCORE: i32 = 1_000_000;
 #[derive(Debug, Clone)]
 pub struct SearchResult {
     /// The chosen move, or `None` at depth 0 / when no legal moves exist.
-    pub best_move: Option<(usize, usize)>,
+    pub best_move: Option<Pos>,
     /// Score from the root side-to-move's perspective.
     pub score: i32,
     /// Total nodes (including leaves) visited during the search.
@@ -55,7 +55,7 @@ pub struct SearchResult {
 #[derive(Debug, Clone)]
 pub struct SearchNode {
     /// The move that led to this node. `None` at the root.
-    pub mv: Option<(usize, usize)>,
+    pub mv: Option<Pos>,
     /// Whose turn it is at this node.
     pub player_to_move: Player,
     /// Plies still to expand below this node.
@@ -81,7 +81,7 @@ pub trait Observer {
     /// Called once before exploring a node.
     fn enter(
         &mut self,
-        mv: Option<(usize, usize)>,
+        mv: Option<Pos>,
         player: Player,
         depth: u32,
         alpha: i32,
@@ -99,7 +99,7 @@ pub struct NoopObserver;
 
 impl Observer for NoopObserver {
     #[inline(always)]
-    fn enter(&mut self, _: Option<(usize, usize)>, _: Player, _: u32, _: i32, _: i32) {}
+    fn enter(&mut self, _: Option<Pos>, _: Player, _: u32, _: i32, _: i32) {}
     #[inline(always)]
     fn leave(&mut self, _: i32, _: bool) {}
 }
@@ -135,7 +135,7 @@ impl Default for TreeObserver {
 impl Observer for TreeObserver {
     fn enter(
         &mut self,
-        mv: Option<(usize, usize)>,
+        mv: Option<Pos>,
         player: Player,
         depth: u32,
         alpha: i32,
@@ -208,9 +208,9 @@ fn negamax<O: Observer>(
     mut beta: i32,
     tt: &mut TranspositionTable,
     observer: &mut O,
-    incoming_mv: Option<(usize, usize)>,
+    incoming_mv: Option<Pos>,
     nodes: &mut u64,
-) -> (i32, Option<(usize, usize)>) {
+) -> (i32, Option<Pos>) {
     *nodes += 1;
     let player = game.current_player();
     observer.enter(incoming_mv, player, depth, alpha, beta);
@@ -278,25 +278,25 @@ fn negamax<O: Observer>(
     }
 
     let mut best_score = i32::MIN + 1;
-    let mut best_mv: Option<(usize, usize)> = None;
+    let mut best_mv: Option<Pos> = None;
     let mut pruned = false;
 
-    for (x, y) in moves {
+    for mv in moves {
         // generate_moves already filters illegal placements, but play_move
         // is still the source of truth — skip defensively if it rejects.
-        if game.play_move(x, y).is_err() {
+        if game.play_pos(mv).is_err() {
             continue;
         }
 
         let (child_score, _) =
-            negamax(game, depth - 1, -beta, -alpha, tt, observer, Some((x, y)), nodes);
+            negamax(game, depth - 1, -beta, -alpha, tt, observer, Some(mv), nodes);
         let score = -child_score;
 
         game.undo_move().expect("undo_move must succeed after a successful play_move");
 
         if score > best_score {
             best_score = score;
-            best_mv = Some((x, y));
+            best_mv = Some(mv);
         }
         if best_score > alpha {
             alpha = best_score;
@@ -400,7 +400,7 @@ mod tests {
         let mut tt = TranspositionTable::new(0);
         let result = best_move(&mut game, 1, &mut tt);
         // On an empty board generate_moves yields exactly (9, 9).
-        assert_eq!(result.best_move, Some((9, 9)));
+        assert_eq!(result.best_move, Some(Pos::from_xy(9, 9)));
     }
 
     #[test]
@@ -414,8 +414,8 @@ mod tests {
         let _ = best_move(&mut game, 2, &mut tt);
 
         assert_eq!(game.history.len(), history_before);
-        assert_eq!(game.board.cell_at(9, 9), Some(Player::Black));
-        assert_eq!(game.board.cell_at(10, 9), Some(Player::White));
+        assert_eq!(game.board.cell_at_xy(9, 9), Some(Player::Black));
+        assert_eq!(game.board.cell_at_xy(10, 9), Some(Player::White));
     }
 
     #[test]
@@ -437,7 +437,7 @@ mod tests {
         let result = best_move(&mut game, 2, &mut tt);
         assert_eq!(
             result.best_move,
-            Some((4, 9)),
+            Some(Pos::from_xy(4, 9)),
             "White must block the only winning square",
         );
     }
@@ -518,8 +518,8 @@ mod tests {
         let r1 = best_move(&mut g1, 4, &mut tt_empty);
         let r2 = best_move(&mut g2, 4, &mut tt);
 
-        println!("no TT best move: {}, {}", r1.best_move.unwrap().0, r1.best_move.unwrap().1);
-        println!("TT best move: {}, {}", r2.best_move.unwrap().0, r2.best_move.unwrap().1);
+        println!("no TT best move: {}", r1.best_move.unwrap());
+        println!("TT best move: {}", r2.best_move.unwrap());
 
         assert_eq!(r1.best_move, r2.best_move, "best move differs with TT");
         assert_eq!(r1.score, r2.score, "score differs with TT");

--- a/engine/src/board.rs
+++ b/engine/src/board.rs
@@ -14,7 +14,7 @@
 //! how that interacts with pattern recognition.
 
 use crate::constants::{BOARD_SIZE, BOARD_SIZE_I, CELL_COUNT};
-use crate::game::{Cell, Player};
+use crate::game::{Cell, Player, Pos};
 const WORD_COUNT: usize = CELL_COUNT.div_ceil(64);
 
 /// One player's stones, stored as a bitmap with one bit per cell.
@@ -34,19 +34,24 @@ impl BitBoard {
             words: [0; 6]
         }
     }
-
+    /// Set the bit at `idx`.
+    #[inline]
     fn set(&mut self, idx: usize) {
         let w = idx / 64;
         let b = idx % 64;
         self.words[w] |= 1u64 << b;
     }
 
+    /// Clear the bit at `idx`.
+    #[inline]
     fn clear(&mut self, idx: usize) {
         let w = idx / 64;
         let b = idx % 64;
         self.words[w] &= !(1u64 << b);
     }
 
+    /// Returns whether the bit at `idx` is set.
+    #[inline]
     fn get(&self, idx: usize) -> bool {
         let w = idx / 64;
         let b = idx % 64;
@@ -54,26 +59,28 @@ impl BitBoard {
     }
 
     /// Map `(x, y)` to a flat bit index in row-major order.
+    #[allow(dead_code)]
+    #[inline]
     fn index(x: usize, y: usize) -> usize {
         y * BOARD_SIZE + x
     }
 
     /// Mark cell `(x, y)` as containing a stone.
-    pub fn place_stone(&mut self, x: usize, y: usize) {
-        let idx = Self::index(x, y);
-        self.set(idx);
+    #[inline]
+    pub fn place_stone(&mut self, pos: Pos) {
+        self.set(pos.idx());
     }
 
     /// Clear the stone at cell `(x, y)`.
-    pub fn remove_stone(&mut self, x: usize, y: usize) {
-        let idx = Self::index(x, y);
-        self.clear(idx);
+    #[inline]
+    pub fn remove_stone(&mut self, pos: Pos) {
+        self.clear(pos.idx());
     }
 
     /// Whether cell `(x, y)` holds a stone.
-    pub fn is_occupied(&self, x: usize, y: usize) -> bool {
-        let idx = Self::index(x, y);
-        self.get(idx)
+    #[inline]
+    pub fn is_occupied(&self, pos: Pos) -> bool {
+        self.get(pos.idx())
     }
 
     /// Bitwise OR with another bitboard. Used to compute "any stone here".
@@ -108,23 +115,27 @@ impl Board {
     ///
     /// No bounds or occupancy check is performed - callers should go
     /// through [`Board::empty_check`] first.
-    pub fn place_stone(&mut self, x: usize, y: usize, player: Player) {
-        self.boards[player.idx()].place_stone(x, y);
+    #[inline]
+    pub fn place_stone(&mut self, pos: Pos, player: Player) {
+        self.boards[player.idx()].place_stone(pos);
     }
 
     /// Remove `player`'s stone at `(x, y)`. Used by undo and capture.
-    pub fn remove_stone(&mut self, x: usize, y: usize, player: Player) {
-        self.boards[player.idx()].remove_stone(x, y);
+    #[inline]
+    pub fn remove_stone(&mut self, pos: Pos, player: Player) {
+        self.boards[player.idx()].remove_stone(pos);
     }
 
     /// Check if the given coordinate contains the player
-    pub fn has(&self, x: usize, y: usize, player: Player) -> bool {
-        self.boards[player.idx()].is_occupied(x, y)
+    #[inline]
+    pub fn has(&self, pos: Pos, player: Player) -> bool {
+        self.boards[player.idx()].is_occupied(pos)
     }
 
     /// Whether `(x, y)` is empty for *both* players.
-    pub fn is_empty(&self, x: usize, y: usize) -> bool {
-        !self.has(x, y, Player::Black) && !self.has(x, y, Player::White)
+    #[inline]
+    pub fn is_empty(&self, pos: Pos) -> bool {
+        !self.has(pos, Player::Black) && !self.has(pos, Player::White)
     }
 
     /// Validate that `(x, y)` is a legal placement target.
@@ -133,24 +144,40 @@ impl Board {
     ///
     /// - `"Out of bounds"` if `x` or `y` is outside `0..BOARD_SIZE`.
     /// - `"Cell already occupied"` if either player has a stone there.
-    pub fn empty_check(&self, x: usize, y: usize) -> Result<(), &'static str> {
-        if x >= BOARD_SIZE || y >= BOARD_SIZE {
+    pub fn empty_check(&self, pos: Pos) -> Result<(), &'static str> {
+        if pos.idx() >= CELL_COUNT {
             return Err("Out of bounds");
         }
 
-        if !self.is_empty(x, y) {
+        if !self.is_empty(pos) {
             return Err("Cell already occupied");
         }
+
         Ok(())
+    }
+
+    /// Look up the contents of cell `Pos`.
+    ///
+    /// Returns `Some(Player)` if a stone is present, `None` if empty.
+    pub fn cell_at(&self, pos: Pos) -> Cell {
+        if self.boards[Player::Black.idx()].is_occupied(pos) {
+            Some(Player::Black)
+        } else if self.boards[Player::White.idx()].is_occupied(pos) {
+            Some(Player::White)
+        } else {
+            None
+        }
     }
 
     /// Look up the contents of cell `(x, y)`.
     ///
     /// Returns `Some(Player)` if a stone is present, `None` if empty.
-    pub fn cell_at(&self, x: usize, y: usize) -> Cell {
-        if self.boards[Player::Black.idx()].is_occupied(x, y) {
+    #[allow(dead_code)]
+    pub fn cell_at_xy(&self, x: usize, y: usize) -> Cell {
+        let pos = Pos::from_xy(x, y);
+        if self.boards[Player::Black.idx()].is_occupied(pos) {
             Some(Player::Black)
-        } else if self.boards[Player::White.idx()].is_occupied(x, y) {
+        } else if self.boards[Player::White.idx()].is_occupied(pos) {
             Some(Player::White)
         } else {
             None
@@ -204,23 +231,38 @@ impl Board {
         max_len: u32,
         player: Player,
     ) -> (u32, u32, u32) {
-        let opponent = player.opponent();
+        let me_board = &self.boards[player.idx()];
+        let opp_board =
+            &self.boards[player.opponent().idx()];
+
         let mut me = 0u32;
         let mut opp = 0u32;
         let mut len = 0u32;
+
         let mut x = x0;
         let mut y = y0;
-        while len < max_len && (0..BOARD_SIZE_I).contains(&x) && (0..BOARD_SIZE_I).contains(&y) {
-            let (ux, uy) = (x as usize, y as usize);
-            if self.has(ux, uy, player) {
+
+        while len < max_len
+            && x >= 0
+            && y >= 0
+            && x < BOARD_SIZE_I
+            && y < BOARD_SIZE_I
+        {
+            let idx =
+                (y as usize) * BOARD_SIZE
+                + (x as usize);
+
+            if me_board.get(idx) {
                 me |= 1 << len;
-            } else if self.has(ux, uy, opponent) {
+            } else if opp_board.get(idx) {
                 opp |= 1 << len;
             }
+
             x += dx;
             y += dy;
             len += 1;
         }
+
         (me, opp, len)
     }
 
@@ -330,7 +372,8 @@ impl Board {
             let mut row_str = String::new();
 
             for x in 0..width {
-                let symbol = match self.cell_at(x, y) {
+                let pos = Pos::from_xy(x, y);
+                let symbol = match self.cell_at(pos) {
                     None => ".",
                     Some(Player::Black) => "X",
                     Some(Player::White) => "O",

--- a/engine/src/board.rs
+++ b/engine/src/board.rs
@@ -22,6 +22,7 @@ const WORD_COUNT: usize = CELL_COUNT.div_ceil(64);
 /// Cells are flattened in row-major order: bit `y * BOARD_SIZE + x` is set
 /// when that cell holds a stone. Six `u64` words is enough for 19×19 = 361
 /// cells with room to spare.
+#[derive(Clone)]
 pub struct BitBoard {
     words: [u64; WORD_COUNT],
 }
@@ -90,6 +91,7 @@ impl BitBoard {
 /// The full game board: one [`BitBoard`] per player.
 ///
 /// Indexed `boards[player.idx()]`; black is index 0 and white is index 1.
+#[derive(Clone)]
 pub struct Board {
     boards: [BitBoard; 2],
 }

--- a/engine/src/game.rs
+++ b/engine/src/game.rs
@@ -155,6 +155,7 @@ impl std::fmt::Display for Move {
 /// All public fields are mutated in place by [`Game::play_move`] and
 /// [`Game::undo_move`]; nothing is reference-counted or cloned. The search
 /// uses make/unmake against a single `Game` rather than copying.
+#[derive(Clone)]
 pub struct Game {
     /// Stone placements.
     pub board: Board,
@@ -165,11 +166,12 @@ pub struct Game {
     /// Capture pair counts as `(black, white)`. Five pairs wins.
     pub captures: (u8, u8),
     /// Zobrist hash of the current game state (board, captures, side-to-move), updated incrementally for fast position lookup in search.
-    hash: u64,
+    pub hash: u64,
 }
 
 /// Whether the game is still being played, has been won, or is drawn.
 #[allow(dead_code)]
+#[derive(Clone)]
 pub enum GameStatus {
     /// More moves are legal.
     Ongoing,

--- a/engine/src/game.rs
+++ b/engine/src/game.rs
@@ -629,6 +629,7 @@ impl Game {
                 moves.push((x, y));
             }
         }
+        moves.sort_unstable();
         moves
     }
 }

--- a/engine/src/game.rs
+++ b/engine/src/game.rs
@@ -24,6 +24,7 @@
 use crate::constants::BOARD_SIZE;
 use crate::constants::BOARD_SIZE_I;
 use crate::board::Board;
+use crate::constants::CELL_COUNT;
 use crate::zobrist::ZOBRIST;
 
 /// Chebyshev radius used by [`Game::generate_moves`] to grow candidate
@@ -45,7 +46,7 @@ pub const MOVE_GEN_RADIUS: isize = 1;
 /// ```
 #[macro_export]
 macro_rules! play {
-    ($game:expr, $x:expr, $y:expr) => {{
+    ($game:expr, $x:expr, $y: expr) => {{
         let result = $game.play_move($x, $y);
         $game.print_board(true);
         result
@@ -82,7 +83,28 @@ pub enum Direction {
 }
 
 impl Direction {
+    #[inline]
+    pub fn offset(self) -> isize {
+        match self {
+            Direction::Horizontal => 1,
+            Direction::Vertical => BOARD_SIZE as isize,
+            Direction::Diagonal => BOARD_SIZE as isize + 1,
+            Direction::AntiDiagonal => BOARD_SIZE as isize - 1,
+        }
+    }
+
+    #[inline]
+    pub fn all() -> [Direction; 4] {
+        [
+            Direction::Horizontal,
+            Direction::Vertical,
+            Direction::Diagonal,
+            Direction::AntiDiagonal,
+        ]
+    }
+
     /// The unit `(dx, dy)` step for this direction.
+    #[inline]
     pub fn delta(self) -> (isize, isize) {
         match self {
             Direction::Horizontal => (1, 0),
@@ -96,6 +118,7 @@ impl Direction {
     ///
     /// Used by win and capture checks that need to scan every line through
     /// a given cell.
+    #[inline]
     pub fn all_directions() -> [(isize, isize); 4] {
         [
             Direction::Horizontal.delta(),   // (1, 0)
@@ -132,22 +155,10 @@ impl Player {
 #[allow(dead_code)]
 #[derive(Clone)]
 pub struct Move {
-    /// Column where the stone was placed.
-    pub x: usize,
-    /// Row where the stone was placed.
-    pub y: usize,
+    /// Position where the stone was placed.
+    pub pos: Pos,
     /// Coordinates of opponent stones captured by this move.
-    pub captured: Vec<(usize, usize)>,
-}
-
-impl std::fmt::Display for Move {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        // Write strictly the first element into the supplied output
-        // stream: `f`. Returns `fmt::Result` which indicates whether the
-        // operation succeeded or failed. Note that `write!` uses syntax which
-        // is very similar to `println!`.
-        write!(f, "[{}, {}]", self.x, self.y)
-    }
+    pub captured: Vec<Pos>,
 }
 
 /// The complete state of a Gomoku game.
@@ -183,7 +194,7 @@ pub enum GameStatus {
 
 /// Compact board position as a linear index (y * 19 + x).
 /// Used for fast indexing and hashing without passing (x, y) pairs.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Pos(pub usize);
 
 impl Pos {
@@ -198,6 +209,56 @@ impl Pos {
     #[inline]
     pub fn to_xy(self) -> (usize, usize) {
         (self.0 % BOARD_SIZE, self.0 / BOARD_SIZE)
+    }
+
+    #[inline]
+    pub fn from_xy(x: usize, y: usize) -> Self {
+        Self(y * BOARD_SIZE + x)
+    }
+
+    #[inline]
+    pub fn offset(self, dir: Direction, step: isize) -> Option<Pos> {
+        let next = self.idx() as isize + dir.offset() * step;
+
+        if !(0..(CELL_COUNT) as isize).contains(&next) {
+            return None;
+        }
+
+        let next = Pos(next as usize);
+
+        if !self.is_valid_step(next, dir) {
+            return None;
+        }
+
+        Some(next)
+    }
+
+    fn is_valid_step(self, next: Pos, dir: Direction) -> bool {
+        let x1 = self.idx() % BOARD_SIZE;
+        let y1 = self.idx() / BOARD_SIZE;
+
+        let x2 = next.idx() % BOARD_SIZE;
+        let y2 = next.idx() / BOARD_SIZE;
+
+        match dir {
+            Direction::Horizontal => y1 == y2,
+            Direction::Vertical => x1 == x2,
+            Direction::Diagonal => {
+                x1.abs_diff(x2) == y1.abs_diff(y2)
+            }
+            Direction::AntiDiagonal => {
+                x1.abs_diff(x2) == y1.abs_diff(y2)
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for Pos {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let x = self.0 % BOARD_SIZE;
+        let y = self.0 / BOARD_SIZE;
+
+        write!(f, "[{}, {}]", x, y)
     }
 }
 
@@ -267,7 +328,24 @@ impl Game {
         self.player_at_move(self.history.len())
     }
 
-    /// Place the current player's stone at `(x, y)` and update the game state.
+    /// Place the current player's stone at `(x, y)`.
+    ///
+    /// This is a public coordinate-based wrapper around [`Game::play_pos`]
+    /// that validates bounds before converting to [`Pos`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `"Out of bounds"` if `(x, y)` lies outside the board,
+    /// or any error propagated from [`Game::play_pos`].
+    pub fn play_move(&mut self, x: usize, y: usize) -> Result<(), &'static str> {
+        if x >= BOARD_SIZE || y >= BOARD_SIZE {
+            return Err("Out of bounds");
+        }
+        let pos = Pos::from_xy(x, y);
+        self.play_pos(pos)
+    }
+
+    /// Place the current player's stone at `Pos` and update the game state.
     ///
     /// Applies captures, checks for the double-three rule, and updates
     /// [`Game::status`] if the move ends the game.
@@ -289,18 +367,17 @@ impl Game {
     /// - `"Game already finished"` when called after a win or draw.
     /// - `"Double three is forbidden"` when the move would create two
     ///   simultaneous free threes.
-    pub fn play_move(&mut self, x: usize, y: usize) -> Result<(), &'static str> {
-        self.board.empty_check(x, y)?;
+    pub fn play_pos(&mut self, pos: Pos) -> Result<(), &'static str> {
+        self.board.empty_check(pos)?;
         if !matches!(self.status, GameStatus::Ongoing) {
             return Err("Game already finished");
         }
-        let pos = Pos(y * BOARD_SIZE + x);
-        let player = self.current_player();
+        let player= self.current_player();
 
-        self.board.place_stone(x, y, player);
+        self.board.place_stone(pos, player);
 
-        if self.count_free_threes(x, y) >= 2 {
-            self.board.remove_stone(x, y, player);
+        if self.count_free_threes(pos) >= 2 {
+            self.board.remove_stone(pos, player);
             return Err("Double three is forbidden");
         }
 
@@ -310,11 +387,10 @@ impl Game {
         self.hash_side(player.opponent());
 
         // apply captures
-        let captured = self.apply_captures(x, y);
+        let captured = self.apply_captures(pos);
 
-        for &(cx, cy) in &captured {
-            let pos = Pos(cy * BOARD_SIZE + cx);
-            self.hash_remove(pos, player.opponent());
+        for &capture in &captured {
+            self.hash_remove(capture, player.opponent());
         }
 
         // update capture count
@@ -335,8 +411,7 @@ impl Game {
         }
 
         self.history.push(Move {
-            x,
-            y,
+            pos,
             captured,
         });
 
@@ -348,7 +423,7 @@ impl Game {
                 self.status = GameStatus::Win(Player::White);
             }
             _ => {
-                if self.check_win(x, y) {
+                if self.check_win(pos) {
                     self.status = GameStatus::Win(player)
                 } else if self.board.is_full() {
                     self.status = GameStatus::Draw;
@@ -359,7 +434,6 @@ impl Game {
 
         Ok(())
     }
-
 
     /// Reverse the most recent move, restoring captured stones and capture
     /// counts. Resets [`Game::status`] to [`GameStatus::Ongoing`].
@@ -377,40 +451,38 @@ impl Game {
     ///
     /// - `"No moves to undo"` if the history is empty.
     pub fn undo_move(&mut self) -> Result<(), String> {
-
         let last = self.history.pop().ok_or("No moves to undo")?;
         let last_player = self.current_player();
-        let last_opponent = self.current_player().opponent();
+        let last_opponent = last_player.opponent();
 
-        let pos = Pos(last.y * BOARD_SIZE + last.x);
-        self.board.remove_stone(last.x, last.y, last_player);
+        self.board.remove_stone(last.pos, last_player);
 
         // undo hash
-        self.hash_remove(pos, last_player);
+        self.hash_remove(last.pos, last_player);
+
         self.hash_side(last_opponent);
         self.hash_side(last_player);
 
-        for &(cx, cy) in &last.captured {
-            self.board.place_stone(cx, cy, last_opponent);
-            let pos = Pos(cy * BOARD_SIZE + cx);
-            self.hash_place(pos, last_opponent);
+        for &captured_pos in &last.captured {
+            self.board.place_stone(captured_pos, last_opponent);
+
+            self.hash_place(captured_pos, last_opponent);
         }
 
         let pairs = last.captured.len() / 2;
 
         match last_player {
             Player::Black => {
-                // hash the previous count out, and the new one in
                 self.hash_capture(last_player, self.captures.0);
                 self.captures.0 -= pairs as u8;
                 self.hash_capture(last_player, self.captures.0);
-            },
+            }
+
             Player::White => {
-                // hash the previous count out, and the new one in
                 self.hash_capture(last_player, self.captures.1);
                 self.captures.1 -= pairs as u8;
                 self.hash_capture(last_player, self.captures.1);
-            },
+            }
         }
 
         self.status = GameStatus::Ongoing;
@@ -425,12 +497,34 @@ impl Game {
             print!("\n-------\nTurn {:2}", self.history.len());
 
             if let Some(last_move) = self.history.last() {
-                print!(" | Move {}", last_move);
+                print!(" | Move {}", last_move.pos);
             }
 
             println!();
         }
         self.board.print_board();
+    }
+
+    fn count_direction(
+        &self,
+        start: Pos,
+        dir: Direction,
+        sign: isize,
+        player: Player,
+    ) -> usize {
+        let mut count = 0;
+        let mut current = start;
+
+        while let Some(next) = current.offset(dir, sign) {
+            if self.board.cell_at(next) != Some(player) {
+                break;
+            }
+
+            count += 1;
+            current = next;
+        }
+
+        count
     }
 
     /// Whether the stone at `(x, y)` participates in a 5+ run along any
@@ -440,32 +534,23 @@ impl Game {
     /// hands the detection off to [`crate::patterns::count_patterns`].
     /// Off-board cells fall outside the packed window, so the board edge
     /// acts as a wall — same convention used by [`Game::is_free_three`].
-    pub fn check_win(&self, x: usize, y: usize) -> bool {
-        let player = match self.board.cell_at(x, y) {
+    pub fn check_win(&self, pos: Pos) -> bool {
+        let player = match self.board.cell_at(pos) {
             Some(p) => p,
             None => return false,
         };
 
-        for (dx, dy) in Direction::all_directions() {
-            // Walk back up to 4 cells along (-dx, -dy) so a 5-run that
-            // ends at (x, y) still fits in the packed line.
-            let mut x0 = x as isize;
-            let mut y0 = y as isize;
-            for _ in 0..4 {
-                let nx = x0 - dx;
-                let ny = y0 - dy;
-                if !(0..BOARD_SIZE_I).contains(&nx) || !(0..BOARD_SIZE_I).contains(&ny) {
-                    break;
-                }
-                x0 = nx;
-                y0 = ny;
-            }
+        for dir in Direction::all() {
+            let mut count = 1;
 
-            let (me, opp, len) = self.board.pack_line(x0, y0, dx, dy, 9, player);
-            if crate::patterns::count_patterns(me, opp, len).fives > 0 {
+            count += self.count_direction(pos, dir, 1, player);
+            count += self.count_direction(pos, dir, -1, player);
+
+            if count >= 5 {
                 return true;
             }
         }
+
         false
     }
 
@@ -475,52 +560,46 @@ impl Game {
     /// `played, opp, opp, played`, the two opponent stones are removed.
     /// Returns the coordinates of the removed stones so the move can be
     /// undone later.
-    fn apply_captures(&mut self, x: usize, y: usize) -> Vec<(usize, usize)> {
+    fn apply_captures(&mut self, pos: Pos) -> Vec<Pos> {
         let mut captured = Vec::new();
+
         let player = self.current_player();
         let opponent = player.opponent();
 
-        for (dx, dy) in Direction::all_directions() {
-            for &(sx, sy) in &[(dx, dy), (-dx, -dy)] {
-                let x1 = x as isize + sx;
-                let y1 = y as isize + sy;
+        for dir in Direction::all() {
+            for step in [-1, 1] {
+                let p1 = pos.offset(dir, step);
+                let p2 = pos.offset(dir, step * 2);
+                let p3 = pos.offset(dir, step * 3);
 
-                let x2 = x as isize + 2 * sx;
-                let y2 = y as isize + 2 * sy;
-
-                let x3 = x as isize + 3 * sx;
-                let y3 = y as isize + 3 * sy;
-
-                if x3 < 0 || y3 < 0 || x3 >= BOARD_SIZE_I || y3 >= BOARD_SIZE_I {
+                let (Some(p1), Some(p2), Some(p3)) = (p1, p2, p3)
+                else {
                     continue;
-                }
+                };
 
-                let (x1, y1) = (x1 as usize, y1 as usize);
-                let (x2, y2) = (x2 as usize, y2 as usize);
-                let (x3, y3) = (x3 as usize, y3 as usize);
-
-                if self.board.cell_at(x1, y1) == Some(opponent)
-                    && self.board.cell_at(x2, y2) == Some(opponent)
-                    && self.board.cell_at(x3, y3) == Some(player)
+                if self.board.cell_at(p1) == Some(opponent)
+                    && self.board.cell_at(p2) == Some(opponent)
+                    && self.board.cell_at(p3) == Some(player)
                 {
-                    self.board.remove_stone(x1, y1, opponent);
-                    self.board.remove_stone(x2, y2, opponent);
+                    self.board.remove_stone(p1, opponent);
+                    self.board.remove_stone(p2, opponent);
 
-                    captured.push((x1, y1));
-                    captured.push((x2, y2));
+                    captured.push(p1);
+                    captured.push(p2);
                 }
             }
         }
+
         captured
     }
 
     /// How many of the four directions show a free three through `(x, y)`.
     /// Used to enforce the no-double-three rule.
-    fn count_free_threes(&self, x: usize, y: usize) -> u32 {
+    fn count_free_threes(&self, pos: Pos) -> u32 {
         let mut count = 0;
 
         for (dx, dy) in Direction::all_directions() {
-            if self.is_free_three(x, y, dx, dy) {
+            if self.is_free_three(pos, dx, dy) {
                 count += 1;
             }
         }
@@ -536,8 +615,8 @@ impl Game {
     /// Off-board cells are dropped from the window — they act as walls,
     /// so a 6-cell pattern that requires an empty endpoint won't match
     /// against the board edge.
-    fn is_free_three(&self, x: usize, y: usize, dx: isize, dy: isize) -> bool {
-        let player = match self.board.cell_at(x, y) {
+    fn is_free_three(&self, pos: Pos, dx: isize, dy: isize) -> bool {
+        let player = match self.board.cell_at(pos) {
             Some(p) => p,
             None => return false,
         };
@@ -545,13 +624,15 @@ impl Game {
         let mut me = 0u32;
         let mut opp = 0u32;
         let mut len = 0u32;
+        let (x, y) = pos.to_xy();
         for i in -4..=4 {
             let cx = x as isize + i * dx;
             let cy = y as isize + i * dy;
             if cx < 0 || cy < 0 || cx >= BOARD_SIZE_I || cy >= BOARD_SIZE_I {
                 continue;
             }
-            match self.board.cell_at(cx as usize, cy as usize) {
+            let check_pos = Pos::from_xy(cx as usize, cy as usize);
+            match self.board.cell_at(check_pos) {
                 Some(p) if p == player => me |= 1 << len,
                 Some(_) => opp |= 1 << len,
                 None => {}
@@ -567,14 +648,19 @@ impl Game {
     /// Probes by temporarily placing the stone, counting the free threes
     /// it creates, and undoing the placement. Used as the legality filter
     /// in [`Game::generate_moves`].
-    fn is_valid_move(&mut self, x: usize, y:usize) -> bool {
-        if !self.board.is_empty(x, y) { return false; }
+    fn is_valid_move(&mut self, pos: Pos) -> bool {
+        if !self.board.is_empty(pos) {
+            return false;
+        }
 
         let player = self.current_player();
-        self.board.place_stone(x, y, player);
 
-        let valid = self.count_free_threes(x, y) < 2;
-        self.board.remove_stone(x, y, player);
+        self.board.place_stone(pos, player);
+
+        let valid = self.count_free_threes(pos) < 2;
+
+        self.board.remove_stone(pos, player);
+
         valid
     }
 
@@ -584,54 +670,66 @@ impl Game {
     /// game at the center. Otherwise returns every empty cell within
     /// [`MOVE_GEN_RADIUS`] of an existing stone that passes
     /// [`Game::is_valid_move`] (i.e. doesn't create a double three).
-    pub fn generate_moves(&mut self) -> Vec<(usize, usize)> {
+    pub fn generate_moves(&mut self) -> Vec<Pos> {
         use std::collections::HashSet;
 
         if self.history.is_empty() {
-            return vec![(9, 9)];
+            return vec![Pos::from_xy(9, 9)];
         }
 
         let mut candidates = HashSet::new();
 
-        for y in 0..BOARD_SIZE {
-            for x in 0..BOARD_SIZE {
-                if self.board.is_empty(x, y) {
-                    continue;
-                }
+        for idx in 0..CELL_COUNT {
+            let pos = Pos(idx);
 
-                for dy in -MOVE_GEN_RADIUS..=MOVE_GEN_RADIUS {
-                    for dx in -MOVE_GEN_RADIUS..=MOVE_GEN_RADIUS {
-                        if dx == 0 && dy == 0 {
-                            continue;
-                        }
+            if self.board.is_empty(pos) {
+                continue;
+            }
 
-                        let nx = x as isize + dx;
-                        let ny = y as isize + dy;
+            let (x, y) = pos.to_xy();
 
-                        if nx < 0 || ny < 0 || nx >= BOARD_SIZE_I || ny >= BOARD_SIZE_I {
-                            continue;
-                        }
+            let x = x as isize;
+            let y = y as isize;
 
-                        let nx = nx as usize;
-                        let ny = ny as usize;
-
-                        if !self.board.is_empty(nx, ny) {
-                            continue;
-                        }
-
-                        candidates.insert((nx, ny));
+            for dy in -MOVE_GEN_RADIUS..=MOVE_GEN_RADIUS {
+                for dx in -MOVE_GEN_RADIUS..=MOVE_GEN_RADIUS {
+                    if dx == 0 && dy == 0 {
+                        continue;
                     }
+
+                    let nx = x + dx;
+                    let ny = y + dy;
+
+                    if nx < 0
+                        || ny < 0
+                        || nx >= BOARD_SIZE_I
+                        || ny >= BOARD_SIZE_I
+                    {
+                        continue;
+                    }
+
+                    let candidate =
+                        Pos::from_xy(nx as usize, ny as usize);
+
+                    if !self.board.is_empty(candidate) {
+                        continue;
+                    }
+
+                    candidates.insert(candidate);
                 }
             }
         }
+
         let mut moves = Vec::new();
 
-        for (x, y) in candidates {
-            if self.is_valid_move(x, y) {
-                moves.push((x, y));
+        for pos in candidates {
+            if self.is_valid_move(pos) {
+                moves.push(pos);
             }
         }
-        moves.sort_unstable();
+
+        moves.sort_unstable_by_key(|p| p.idx());
+
         moves
     }
 }
@@ -673,8 +771,8 @@ fn test_capture_simple() {
 
     play!(game, 3, 0).unwrap(); // X → capture
 
-    assert_eq!(game.board.cell_at(1, 0), None);
-    assert_eq!(game.board.cell_at(2, 0), None);
+    assert_eq!(game.board.cell_at_xy(1, 0), None);
+    assert_eq!(game.board.cell_at_xy(2, 0), None);
 }
 #[test]
 fn test_double_capture() {
@@ -693,10 +791,10 @@ fn test_double_capture() {
 
     play!(game, 3, 0).unwrap(); // X → should capture both pairs
 
-    assert_eq!(game.board.cell_at(1, 0), None);
-    assert_eq!(game.board.cell_at(2, 0), None);
-    assert_eq!(game.board.cell_at(4, 0), None);
-    assert_eq!(game.board.cell_at(5, 0), None);
+    assert_eq!(game.board.cell_at_xy(1, 0), None);
+    assert_eq!(game.board.cell_at_xy(2, 0), None);
+    assert_eq!(game.board.cell_at_xy(4, 0), None);
+    assert_eq!(game.board.cell_at_xy(5, 0), None);
 }
 
 #[test]
@@ -764,7 +862,7 @@ fn test_generate_moves_empty_board() {
 
     let moves = game.generate_moves();
 
-    assert_eq!(moves, vec![(9, 9)]);
+    assert_eq!(moves, vec![Pos::from_xy(9, 9)]);
 }
 
 #[test]
@@ -775,10 +873,10 @@ fn test_generate_moves_near_single_stone() {
 
     let moves = game.generate_moves();
 
-    assert!(moves.contains(&(8, 8)));
-    assert!(moves.contains(&(9, 8)));
-    assert!(moves.contains(&(10, 10)));
-    assert!(!moves.contains(&(0, 0)));
+    assert!(moves.contains(&Pos::from_xy(8, 8)));
+    assert!(moves.contains(&Pos::from_xy(9, 8)));
+    assert!(moves.contains(&Pos::from_xy(10, 10)));
+    assert!(!moves.contains(&Pos::from_xy(0, 0)));
 }
 
 #[test]
@@ -803,7 +901,7 @@ fn test_undo_simple_move() {
     game.undo_move().unwrap();
     game.print_board(true);
 
-    assert_eq!(game.board.cell_at(9, 9), None);
+    assert_eq!(game.board.cell_at_xy(9, 9), None);
     assert_eq!(game.history.len(), 0);
 }
 
@@ -822,8 +920,8 @@ fn test_undo_capture() {
     game.print_board(true);
 
     // stones should be restored
-    assert_eq!(game.board.cell_at(1, 0), Some(Player::White));
-    assert_eq!(game.board.cell_at(2, 0), Some(Player::White));
+    assert_eq!(game.board.cell_at_xy(1, 0), Some(Player::White));
+    assert_eq!(game.board.cell_at_xy(2, 0), Some(Player::White));
 }
 
 #[test]
@@ -836,7 +934,7 @@ fn test_undo_simple_move_hash() {
     game.undo_move().unwrap();
 
     assert_eq!(game.hash, h);
-    assert_eq!(game.board.cell_at(9, 9), None);
+    assert_eq!(game.board.cell_at_xy(9, 9), None);
     assert_eq!(game.history.len(), 0);
 }
 
@@ -857,8 +955,8 @@ fn test_undo_capture_hash() {
     assert_eq!(game.hash, h);
 
     // stones restored
-    assert_eq!(game.board.cell_at(1, 0), Some(Player::White));
-    assert_eq!(game.board.cell_at(2, 0), Some(Player::White));
+    assert_eq!(game.board.cell_at_xy(1, 0), Some(Player::White));
+    assert_eq!(game.board.cell_at_xy(2, 0), Some(Player::White));
 }
 
 #[test]

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -38,6 +38,7 @@
 
 mod ai;
 mod zobrist;
+mod transpose;
 mod board;
 mod constants;
 mod game;

--- a/engine/src/transpose.rs
+++ b/engine/src/transpose.rs
@@ -1,0 +1,118 @@
+//! Fixed-size transposition table used by the alpha-beta search.
+//!
+//! Positions are indexed by Zobrist hash and stored using simple
+//! replacement-by-depth. Each entry stores:
+//!
+//! - the full position hash
+//! - the search depth
+//! - the evaluated score
+//! - a bound classification (`Exact`, `Lower`, `Upper`)
+//! - the best move found from the position
+//!
+//! The table uses a power-of-two size so indexing can use:
+//!
+//! ```ignore
+//! hash & mask
+//! ```
+//!
+//! instead of modulo division.
+/// Type of score stored in the transposition table.
+///
+/// TT scores may represent:
+///
+/// - [`Bound::Exact`] — exact minimax evaluation
+/// - [`Bound::Lower`] — lower bound from a beta cutoff (fail-high)
+/// - [`Bound::Upper`] — upper bound from a fail-low search
+///
+/// Lower/upper bounds are used to tighten alpha-beta windows during
+/// future searches.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Bound {
+    Exact,
+    Lower,
+    Upper,
+}
+
+/// One cached search result stored in the transposition table.
+#[derive(Clone, Copy)]
+pub struct TTEntry {
+    pub key: u64,
+    pub depth: i32,
+    pub score: i32,
+    pub flag: Bound,
+    pub best_move: Option<(usize, usize)>,
+}
+
+#[allow(dead_code)]
+impl TTEntry {
+    /// Sentinel empty entry used to initialize the table.
+    pub fn empty() -> Self {
+        Self {
+            key: 0,
+            depth: -1,
+            score: 0,
+            flag: Bound::Exact,
+            best_move: None,
+        }
+    }
+}
+
+/// Fixed-size transposition table used to cache previously searched
+/// positions during alpha-beta search.
+///
+/// Positions are indexed by Zobrist hash using:
+///
+/// ```ignore
+/// (hash as usize) & mask
+/// ```
+///
+/// Because the table has a fixed size, multiple positions may map to the
+/// same slot (collision). Collisions are resolved using a depth-preferred
+/// replacement policy: deeper search results replace shallower ones.
+pub struct TranspositionTable {
+    /// Table storage.
+    entries: Vec<TTEntry>,
+    // size - 1, used for fast index computation via:
+    // (hash as usize) & mask
+    mask: usize,
+}
+
+#[allow(dead_code)]
+impl TranspositionTable {
+    /// Create a transposition table with `2^size_power` entries.
+    ///
+    /// The table size is rounded to a power of two so indexing can use
+    /// fast bit masking instead of modulo division.
+    pub fn new(size_power: usize) -> Self {
+        let size = 1 << size_power;
+        Self {
+            entries: vec![TTEntry::empty(); size],
+            mask: size - 1,
+        }
+    }
+    /// Look up a position by Zobrist hash.
+    ///
+    /// Returns `None` if the slot is empty or contains a different hash
+    /// due to collision replacement.
+    pub fn get(&self, hash: u64) -> Option<&TTEntry> {
+        let entry = &self.entries[(hash as usize) & self.mask];
+        if entry.key == hash {
+            Some(entry)
+        } else {
+            None
+        }
+    }
+    /// Insert or replace a TT entry.
+    ///
+    /// Replacement policy:
+    /// - empty slots are always replaced
+    /// - deeper searches replace shallower searches
+    pub fn insert (&mut self, hash: u64, new_entry: TTEntry) {
+        let index = (hash as usize) & self.mask;
+        let entry = &mut self.entries[index];
+
+        if entry.key == 0 || new_entry.depth >= entry.depth {
+            *entry = new_entry;
+        }
+    }
+}

--- a/engine/src/transpose.rs
+++ b/engine/src/transpose.rs
@@ -16,6 +16,8 @@
 //! ```
 //!
 //! instead of modulo division.
+
+use crate::game::Pos;
 /// Type of score stored in the transposition table.
 ///
 /// TT scores may represent:
@@ -40,7 +42,7 @@ pub struct TTEntry {
     pub depth: i32,
     pub score: i32,
     pub flag: Bound,
-    pub best_move: Option<(usize, usize)>,
+    pub best_move: Option<Pos>,
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
## Summary

Refactor internal board and search logic to use the `Pos` abstraction instead of passing `(x, y)` coordinate pairs throughout the engine.

`Pos` stores board positions as a compact linear index (`y * BOARD_SIZE + x`) and centralizes board navigation logic.

## Changes
before:
<img width="556" height="64" alt="image" src="https://github.com/user-attachments/assets/4c7429c1-19aa-42bc-8ef1-d6d37889faee" />

after:
<img width="556" height="64" alt="image" src="https://github.com/user-attachments/assets/63849000-f769-4cf7-bbbc-8c1ef1ca966d" />

Closes #34 
