### PR TITLE
[FEATURE] Engine: implement move ordering for negamax search

### DIFF
--- a/engine/src/ai/mod.rs
+++ b/engine/src/ai/mod.rs
@@ -13,6 +13,7 @@
 
 pub mod eval;
 pub mod search;
+pub mod move_ordering;
 
 #[allow(unused_imports)]
 pub use eval::evaluate;

--- a/engine/src/ai/move_ordering.rs
+++ b/engine/src/ai/move_ordering.rs
@@ -1,0 +1,166 @@
+//! Move ordering heuristics for negamax alpha-beta search.
+//!
+//! Candidate moves are scored before expansion to improve alpha-beta
+//! pruning efficiency and reduce the explored search tree.
+//!
+//! Current ordering heuristics include:
+//!
+//! - transposition-table best move
+//! - immediate winning moves
+//! - captures
+//! - local tactical threats
+//! - center proximity
+//!
+//! # Examples
+//!
+//! ```ignore
+//! let moves = game.generate_moves();
+//!
+//! let tt_move = tt
+//!     .get(game.hash())
+//!     .and_then(|entry| entry.best_move);
+//!
+//! let ordered = order_moves(
+//!     &mut game,
+//!     moves,
+//!     tt_move,
+//! );
+//! ```
+use crate::game::{ Direction, Player, Game, GameStatus, Pos };
+use crate::board::Board;
+use crate::patterns::count_patterns;
+
+/// A move paired with its ordering heuristic score.
+#[derive(Debug, Clone, Copy)]
+pub struct ScoredMove {
+    /// Candidate move position.
+    pub mv: Pos,
+    /// Ordering score used for move sorting.
+    pub score: i32,
+}
+
+/// Large bonus forcing the TT best move to be searched first.
+const TT_MOVE_BONUS: i32 = 1_000_000;
+/// Bonus for moves that immediately win the game.
+const WINNING_MOVE_BONUS: i32 = 500_000;
+/// Bonus applied per captured pair.
+const CAPTURE_BONUS: i32 = 100_000;
+
+/// Pack a small local line around `pos` into bit patterns.
+///
+/// Returns `(me, opp, len)` for pattern evaluation.
+fn pack_local_line(
+    board: &Board,
+    pos: Pos,
+    dir: Direction,
+    radius: isize,
+    player: Player,
+) -> (u16, u16, u32) {
+    let mut me = 0u16;
+    let mut opp = 0u16;
+    let mut len = 0;
+
+    for step in -radius..=radius {
+        let bit = 1 << len;
+
+        if let Some(p) = pos.offset(dir, step) {
+            match board.cell_at(p) {
+                Some(stone) if stone == player => me |= bit,
+                Some(_) => opp |= bit,
+                None => {}
+            }
+
+            len += 1;
+        }
+    }
+
+    (me, opp, len)
+}
+
+/// Estimate the tactical strength of playing at `pos`.
+///
+/// Used only for move ordering heuristics.
+fn evaluate_threat(game: &Game, pos: Pos) -> i32 {
+    let player = game.current_player();
+
+    let mut score = 0;
+
+    for dir in Direction::all() {
+        let (me, opp, len) =
+            pack_local_line(&game.board, pos, dir, 4, player);//I'm not sure if the radius should be 4 or 5
+
+        let patterns = count_patterns(me as u32, opp as u32, len);
+        score += patterns.fives as i32 * 100_000;
+        score += patterns.open_four as i32 * 10_000;
+        score += patterns.closed_four as i32 * 2_000;
+        score += patterns.open_three as i32 * 500;
+    }
+
+    score
+}
+
+/// Small positional bonus favoring central moves.
+fn center_score(pos: Pos) -> i32 {
+    let (x, y) = pos.to_xy();
+
+    let dx = (x as i32 - 9).abs();
+    let dy = (y as i32 - 9).abs();
+
+    -(dx + dy)
+}
+
+/// Score and sort candidate moves for alpha-beta search.
+///
+/// Moves are ordered using lightweight tactical heuristics:
+/// - transposition-table best move
+/// - immediate wins
+/// - captures
+/// - local threats
+/// - center proximity
+///
+/// Better move ordering improves pruning efficiency and reduces
+/// the explored search tree.
+pub fn order_moves(
+    game: &mut Game,
+    moves: Vec<Pos>,
+    tt_move: Option<Pos>,
+) -> Vec<Pos> {
+    let mut scored_moves: Vec<ScoredMove> = moves
+        .into_iter()
+        .map(|mv| {
+            let mut score = 0;
+
+            if Some(mv) == tt_move {
+                score += TT_MOVE_BONUS;
+            }
+
+            let current_player = game.current_player();
+            let before_capture = game.capture_count(current_player);
+
+            // place the stone
+            game.play_pos(mv).unwrap();
+
+            // check for win
+            let is_win = game.status == GameStatus::Win(current_player);
+            let captures = game.capture_count(current_player) - before_capture;
+
+            score += evaluate_threat(game, mv);
+
+            score += center_score(mv);
+
+            // add scores
+            if is_win {
+                score += WINNING_MOVE_BONUS;
+            }
+            score += captures as i32 * CAPTURE_BONUS;
+            // remove the stone
+            game.undo_move().unwrap();
+
+            ScoredMove { mv, score }
+        })
+        .collect();
+
+    #[allow(clippy::unnecessary_sort_by)]
+    scored_moves.sort_by(|a, b| b.score.cmp(&a.score));
+    scored_moves.into_iter().map(|s| s.mv).collect()
+}

--- a/engine/src/ai/move_ordering.rs
+++ b/engine/src/ai/move_ordering.rs
@@ -77,17 +77,19 @@ fn pack_local_line(
     (me, opp, len)
 }
 
-/// Estimate the tactical strength of playing at `pos`.
+/// Estimate the tactical strength of playing at `pos` for `player`.
+///
+/// `player` must be the side that just placed the stone at `pos` — not
+/// `game.current_player()`, which after `play_pos` refers to the opponent.
+/// Passing the wrong perspective scores patterns for the opposing side and
+/// inverts the ordering.
 ///
 /// Used only for move ordering heuristics.
-fn evaluate_threat(game: &Game, pos: Pos) -> i32 {
-    let player = game.current_player();
-
+fn evaluate_threat(game: &Game, pos: Pos, player: Player) -> i32 {
     let mut score = 0;
 
     for dir in Direction::all() {
-        let (me, opp, len) =
-            pack_local_line(&game.board, pos, dir, 4, player);//I'm not sure if the radius should be 4 or 5
+        let (me, opp, len) = pack_local_line(&game.board, pos, dir, 4, player);
 
         let patterns = count_patterns(me as u32, opp as u32, len);
         score += patterns.fives as i32 * 100_000;
@@ -144,7 +146,7 @@ pub fn order_moves(
             let is_win = game.status == GameStatus::Win(current_player);
             let captures = game.capture_count(current_player) - before_capture;
 
-            score += evaluate_threat(game, mv);
+            score += evaluate_threat(game, mv, current_player);
 
             score += center_score(mv);
 

--- a/engine/src/ai/search.rs
+++ b/engine/src/ai/search.rs
@@ -201,13 +201,13 @@ fn negamax(
 ///
 /// ```ignore
 /// let mut game = Game::new();
-/// let mut tt = TranspositionTable::new(20);
-/// let result = best_move(&mut game, 4, &mut tt);
+/// let result = best_move(&mut game, 4, 20);
 /// assert_eq!(result.best_move, Some((9, 9))); // center on empty board
 /// ```
-pub fn best_move(game: &mut Game, depth: u32, tt: &mut TranspositionTable) -> SearchResult {
+pub fn best_move(game: &mut Game, depth: u32, tt_size: usize) -> SearchResult {
     let mut nodes = 0u64;
-    let (score, mv) = negamax(game, depth, i32::MIN + 1, i32::MAX - 1, tt, &mut nodes);
+    let mut tt = TranspositionTable::new(tt_size);
+    let (score, mv) = negamax(game, depth, i32::MIN + 1, i32::MAX - 1, &mut tt, &mut nodes);
     SearchResult { best_move: mv, score, nodes_visited: nodes }
 }
 
@@ -219,8 +219,7 @@ mod tests {
     #[test]
     fn depth_zero_returns_eval_and_no_move() {
         let mut game = Game::new();
-        let mut tt = TranspositionTable::new(0);
-        let result = best_move(&mut game, 0, &mut tt);
+        let result = best_move(&mut game, 0, 0);
         assert_eq!(result.best_move, None);
         assert_eq!(result.nodes_visited, 1);
     }
@@ -228,8 +227,7 @@ mod tests {
     #[test]
     fn returns_a_legal_move_on_empty_board() {
         let mut game = Game::new();
-        let mut tt = TranspositionTable::new(0);
-        let result = best_move(&mut game, 1, &mut tt);
+        let result = best_move(&mut game, 1, 0);
         // On an empty board generate_moves yields exactly (9, 9).
         assert_eq!(result.best_move, Some(Pos::from_xy(9, 9)));
     }
@@ -241,8 +239,7 @@ mod tests {
         game.play_move(10, 9).unwrap();
         let history_before = game.history.len();
 
-        let mut tt = TranspositionTable::new(0);
-        let _ = best_move(&mut game, 2, &mut tt);
+        let _ = best_move(&mut game, 2, 0);
 
         assert_eq!(game.history.len(), history_before);
         assert_eq!(game.board.cell_at_xy(9, 9), Some(Player::Black));
@@ -264,8 +261,7 @@ mod tests {
         game.play_move(3, 9).unwrap();    // B
         // White to move.
 
-        let mut tt = TranspositionTable::new(0);
-        let result = best_move(&mut game, 2, &mut tt);
+        let result = best_move(&mut game, 2, 0);
         assert_eq!(
             result.best_move,
             Some(Pos::from_xy(4, 9)),
@@ -276,11 +272,9 @@ mod tests {
     fn assert_deterministic(game: &Game, depth: u32) {
         let mut g1 = game.clone();
         let mut g2 = game.clone();
-        let mut tt1 = TranspositionTable::new(20);
-        let mut tt2 = TranspositionTable::new(20);
 
-        let r1 = best_move(&mut g1, depth, &mut tt1);
-        let r2 = best_move(&mut g2, depth, &mut tt2);
+        let r1 = best_move(&mut g1, depth, 20);
+        let r2 = best_move(&mut g2, depth, 20);
 
         assert_eq!(r1.best_move, r2.best_move, "best move differs");
         assert_eq!(r1.score, r2.score, "score differs");
@@ -346,11 +340,8 @@ mod tests {
         let mut g1 = Game::new();
         let mut g2 = g1.clone();
 
-        let mut tt_empty = TranspositionTable::new(0);
-        let mut tt = TranspositionTable::new(20);
-
-        let r1 = best_move(&mut g1, 4, &mut tt_empty);
-        let r2 = best_move(&mut g2, 4, &mut tt);
+        let r1 = best_move(&mut g1, 4, 0);
+        let r2 = best_move(&mut g2, 4, 20);
 
         assert_eq!(r1.best_move, r2.best_move);
         assert_eq!(r1.score, r2.score);
@@ -361,11 +352,8 @@ mod tests {
         let mut g1 = Game::new();
         let mut g2 = g1.clone();
 
-        let mut tt_empty = TranspositionTable::new(0);
-        let mut tt = TranspositionTable::new(20);
-
-        let r1 = best_move(&mut g1, 6, &mut tt_empty);
-        let r2 = best_move(&mut g2, 6, &mut tt);
+        let r1 = best_move(&mut g1, 6, 0);
+        let r2 = best_move(&mut g2, 6, 20);
 
         println!("no TT nodes: {}", r1.nodes_visited);
         println!("TT nodes: {}", r2.nodes_visited);
@@ -378,11 +366,8 @@ mod tests {
         let mut g1 = midgame_position();
         let mut g2 = g1.clone();
 
-        let mut tt_empty = TranspositionTable::new(0);
-        let mut tt = TranspositionTable::new(20);
-
-        let r1 = best_move(&mut g1, 4, &mut tt_empty);
-        let r2 = best_move(&mut g2, 4, &mut tt);
+        let r1 = best_move(&mut g1, 4, 0);
+        let r2 = best_move(&mut g2, 4, 20);
 
         println!("no TT best move: {}", r1.best_move.unwrap());
         println!("TT best move: {}", r2.best_move.unwrap());

--- a/engine/src/ai/search.rs
+++ b/engine/src/ai/search.rs
@@ -22,6 +22,7 @@
 #![allow(dead_code)]
 
 use crate::ai::eval::evaluate;
+use crate::ai::move_ordering::order_moves;
 use crate::game::{Game, GameStatus, Pos};
 use crate::transpose::{Bound, TTEntry, TranspositionTable};
 
@@ -116,40 +117,22 @@ fn negamax(
         return (evaluate(game), None);
     }
 
-    let mut moves = game.generate_moves();
+    let tt_move = tt_entry.and_then(|entry| entry.best_move);
+    let moves = game.generate_moves();
 
-    if moves.is_empty() {
+    //sort the moves
+    let ordered_moves = order_moves(game, moves, tt_move);
+
+    if ordered_moves.is_empty() {
         // No legal continuations but game isn't flagged terminal — treat as
         // a quiet position and hand off to the evaluator.
         return (evaluate(game), None);
     }
 
-    if let Some(entry) = tt_entry {
-        if entry.depth >= depth as i32 {
-            if let Some(tt_mv) = entry.best_move {
-                if let Some(pos) = moves.iter().position(|&m| m == tt_mv) {
-                    // Search the previous best move first to maximize alpha-beta cutoffs.
-                    moves.swap(0, pos);
-                }
-            }
-        }
-    }
-
-    if let Some(entry) = tt_entry {
-        if entry.depth >= depth as i32 {
-            if let Some(tt_mv) = entry.best_move {
-                if let Some(pos) = moves.iter().position(|&m| m == tt_mv) {
-                    // Search the previous best move first to maximize alpha-beta cutoffs.
-                    moves.swap(0, pos);
-                }
-            }
-        }
-    }
-
     let mut best_score = i32::MIN + 1;
     let mut best_mv: Option<Pos> = None;
 
-    for mv in moves {
+    for mv in ordered_moves {
         // generate_moves already filters illegal placements, but play_move
         // is still the source of truth — skip defensively if it rejects.
         if game.play_pos(mv).is_err() {

--- a/engine/src/game.rs
+++ b/engine/src/game.rs
@@ -182,7 +182,7 @@ pub struct Game {
 
 /// Whether the game is still being played, has been won, or is drawn.
 #[allow(dead_code)]
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum GameStatus {
     /// More moves are legal.
     Ongoing,
@@ -315,6 +315,7 @@ impl Game {
     /// Whose move is the `move_index`-th move (zero-indexed).
     ///
     /// Even indices are Black, odd indices are White.
+    #[inline]
     pub fn player_at_move(&self, move_index: usize) -> Player {
         if move_index.is_multiple_of(2) {
             Player::Black
@@ -324,8 +325,20 @@ impl Game {
     }
 
     /// Whose turn it currently is. Derived from `history.len()`.
+    #[inline]
     pub fn current_player(&self) -> Player {
         self.player_at_move(self.history.len())
+    }
+
+    /// Number of capture pairs taken by `player`.
+    ///
+    /// Reaching 5 captured pairs wins the game.
+    #[inline]
+    pub fn capture_count(&self, player: Player) -> u8 {
+        match player {
+            Player::Black => self.captures.0,
+            Player::White => self.captures.1,
+        }
     }
 
     /// Place the current player's stone at `(x, y)`.
@@ -736,7 +749,6 @@ impl Game {
         }
 
         moves.sort_unstable_by_key(|p| p.idx());
-
         moves
     }
 }


### PR DESCRIPTION
## Summary

Add move ordering heuristics to improve alpha-beta pruning efficiency.

Moves are now scored and sorted before expansion using tactical and positional heuristics.

## Changes

- add `order_moves` search helper
- add TT move prioritization
- add immediate winning move detection
- add capture-based move scoring
- add local threat evaluation using packed patterns
- add center proximity heuristic
- introduce `ScoredMove`
- integrate move ordering into negamax search

## Result

Observed roughly 35–40% search speed improvement in benchmarks.

Before:
<img width="497" height="65" alt="image" src="https://github.com/user-attachments/assets/81275e3d-d048-4ac2-a487-f3b621183191" />

After:
<img width="497" height="65" alt="image" src="https://github.com/user-attachments/assets/a64322e5-4d06-4329-8597-c766fa60988d" />

Closes #47
