### PR TITLE
[FEATURE] Engine: add lmr to reduce searched depth for less important moves

### DIFF
--- a/engine-wasm/src/dto.rs
+++ b/engine-wasm/src/dto.rs
@@ -97,8 +97,12 @@ pub struct BestMoveDTO {
     pub r#move: Option<MoveDTO>,
     /// Score from the side-to-move's perspective.
     pub score: i32,
+    /// Deepest fully completed iterative depth.
+    pub depth_reached: u32,
     /// Total nodes (incl. leaves) the search visited.
-    pub nodes_visited: u64,
+    pub total_nodes: u64,
+    /// Deepest ply explored overall.
+    pub max_ply: u32,
 }
 
 /// Read-only snapshot of the game for rendering.

--- a/engine-wasm/src/handle.rs
+++ b/engine-wasm/src/handle.rs
@@ -11,6 +11,8 @@
 //! must call `handle.free()` when it's done with a game, or hold a single
 //! handle for the lifetime of the page.
 
+use std::result;
+
 use engine::ai;
 use engine::constants::BOARD_SIZE;
 use engine::game::Game;
@@ -100,7 +102,9 @@ impl GameHandle {
                 MoveDTO { x: x as u32, y: y as u32 }
             }),
             score: result.score,
-            nodes_visited: result.nodes_visited,
+            depth_reached: result.depth_reached,
+            total_nodes: result.total_nodes,
+            max_ply: result.max_ply
         };
         dto.serialize(&js_serializer()).map_err(into_js_error)
     }

--- a/engine-wasm/src/handle.rs
+++ b/engine-wasm/src/handle.rs
@@ -10,9 +10,6 @@
 //! `wasm-bindgen` reference-counts handles on the JS side. The visualizer
 //! must call `handle.free()` when it's done with a game, or hold a single
 //! handle for the lifetime of the page.
-
-use std::result;
-
 use engine::ai;
 use engine::constants::BOARD_SIZE;
 use engine::game::Game;

--- a/engine/src/ai/config.rs
+++ b/engine/src/ai/config.rs
@@ -5,6 +5,9 @@ pub struct SearchConfig {
 
     /// Maximum search time in milliseconds for iterative deepening.
     pub timeout_ms: u64,
+
+    /// Initial depth used for iterative deepening search.
+    pub iterative_start_depth: u32,
 }
 
 impl Default for SearchConfig {
@@ -12,6 +15,7 @@ impl Default for SearchConfig {
         Self {
             enable_lmr: true,
             timeout_ms: 100,
+            iterative_start_depth: 1,
         }
     }
 }

--- a/engine/src/ai/config.rs
+++ b/engine/src/ai/config.rs
@@ -1,0 +1,17 @@
+/// Runtime configuration for search heuristics and limits.
+pub struct SearchConfig {
+    /// Enable Late Move Reductions during search.
+    pub enable_lmr: bool,
+
+    /// Maximum search time in milliseconds for iterative deepening.
+    pub timeout_ms: u64,
+}
+
+impl Default for SearchConfig {
+    fn default() -> Self {
+        Self {
+            enable_lmr: true,
+            timeout_ms: 100,
+        }
+    }
+}

--- a/engine/src/ai/iterative_deepening.rs
+++ b/engine/src/ai/iterative_deepening.rs
@@ -7,12 +7,53 @@
 //! TT reuse, reducing the explored search tree and improving pruning
 //! efficiency at larger depths.
 use std::time::{Duration, Instant};
-use crate::game::Game;
+use crate::game::{ Game, Pos };
 use crate::transpose::{ TranspositionTable };
-use crate::ai::search::{ SearchResult, best_move_with_tt };
+use crate::ai::negamax;
 
 // Set max to 1 / 5 of the actual time limit
 const TIMEOUT_MS : u64 = 100;
+
+/// What the search returns to the caller.
+#[derive(Debug, Clone)]
+pub struct SearchIterationResult {
+    /// The chosen move, or `None` at depth 0 / when no legal moves exist.
+    pub best_move: Option<Pos>,
+    /// Score from the root side-to-move's perspective.
+    pub score: i32,
+    /// Total nodes (including leaves) visited during the search.
+    pub nodes_visited: u64,
+    /// Deepest ply explored during the search.
+    pub max_ply: u32,
+}
+
+/// Run a single fixed-depth negamax search iteration using
+/// alpha-beta pruning and the shared transposition table.
+pub fn search_iteration(
+    game: &mut Game,
+    depth: u32,
+    tt: &mut TranspositionTable,
+) -> SearchIterationResult {
+    let mut nodes = 0u64;
+    let mut max_ply = 0;
+    let (score, mv) = negamax(
+        game,
+        depth,
+        i32::MIN + 1,
+        i32::MAX - 1,
+        tt,
+        &mut nodes,
+        &mut max_ply,
+        0
+    );
+
+    SearchIterationResult {
+        best_move: mv,
+        score,
+        nodes_visited: nodes,
+        max_ply
+    }
+}
 
 /// Result returned by iterative deepening search.
 ///
@@ -20,7 +61,7 @@ const TIMEOUT_MS : u64 = 100;
 #[allow(dead_code)]
 pub struct IterativeResult {
     /// Best move search result from the final iteration.
-    pub result: SearchResult,
+    pub result: SearchIterationResult,
     /// Deepest fully completed search depth.
     pub depth_reached: u32,
     /// Total nodes seached.
@@ -58,8 +99,8 @@ pub fn iterative_deepening(
             break;
         }
 
-        let result = best_move_with_tt(game, depth, &mut tt);
-
+        let result = search_iteration(game, depth, &mut tt);
+        println!("i: {}, nodes: {}", depth, result.nodes_visited);
         total_nodes += result.nodes_visited;
         best = Some((depth, result));
     }
@@ -187,7 +228,7 @@ mod tests {
         println!("=== Direct Search ===");
         println!("best move: {:?}", direct.best_move);
         println!("score: {}", direct.score);
-        println!("nodes: {}", direct.nodes_visited);
+        println!("nodes: {}", direct.total_nodes);
         println!("time: {:?}", direct_time);
 
         println!();
@@ -231,35 +272,5 @@ mod tests {
 
         // Sanity check that the search remains bounded.
         assert!(elapsed < Duration::from_secs(2));
-    }
-    #[test]
-    fn iterative_depth_10_benchmark() {
-        use std::time::Instant;
-
-        let mut game = midgame_position();
-
-        game.print_board(true);
-        let start = Instant::now();
-
-        let result = iterative_deepening(
-            &mut game,
-            10,
-            20,
-        );
-
-        let elapsed = start.elapsed();
-
-        println!();
-        println!("=== Iterative Deepening Benchmark ===");
-        println!("depth reached: {}", result.depth_reached);
-        println!("best move: {:?}", result.result.best_move);
-        println!("score: {}", result.result.score);
-        println!("total nodes searched: {}", result.total_nodes);
-        println!("elapsed: {:?}", elapsed);
-
-        let ebf = (result.result.nodes_visited as f64)
-            .powf(1.0 / result.depth_reached as f64);
-
-        println!("effective branching factor: {:.2}", ebf);
     }
 }

--- a/engine/src/ai/iterative_deepening.rs
+++ b/engine/src/ai/iterative_deepening.rs
@@ -23,6 +23,8 @@ pub struct IterativeResult {
     pub result: SearchResult,
     /// Deepest fully completed search depth.
     pub depth_reached: u32,
+    /// Total nodes seached.
+    pub total_nodes: u64,
 }
 
 /// Run iterative deepening negamax search up to `max_depth`.
@@ -43,21 +45,23 @@ pub fn iterative_deepening(
     tt_size: usize,
 ) -> IterativeResult {
     let mut best = None;
-
     let mut tt = TranspositionTable::new(tt_size);
-
+    let mut total_nodes = 0;
     let start = Instant::now();
+
     for depth in 1..=max_depth {
-        let result = best_move_with_tt(game, depth, &mut tt);
-
-        let elapsed = start.elapsed();
-        best = Some((depth, result));
-
         // Avoid starting an iteration that is
         // likely to explode exponentially.
+        let elapsed = start.elapsed();
+
         if elapsed > Duration::from_millis(TIMEOUT_MS) {
             break;
         }
+
+        let result = best_move_with_tt(game, depth, &mut tt);
+
+        total_nodes += result.nodes_visited;
+        best = Some((depth, result));
     }
 
     let (depth_reached, result) =
@@ -66,6 +70,7 @@ pub fn iterative_deepening(
     IterativeResult {
         result,
         depth_reached,
+        total_nodes
     }
 }
 
@@ -207,7 +212,6 @@ mod tests {
         use std::time::{Duration, Instant};
 
         let mut game = midgame_position();
-
         let start = Instant::now();
 
         let result = iterative_deepening(
@@ -227,5 +231,35 @@ mod tests {
 
         // Sanity check that the search remains bounded.
         assert!(elapsed < Duration::from_secs(2));
+    }
+    #[test]
+    fn iterative_depth_10_benchmark() {
+        use std::time::Instant;
+
+        let mut game = midgame_position();
+
+        game.print_board(true);
+        let start = Instant::now();
+
+        let result = iterative_deepening(
+            &mut game,
+            10,
+            20,
+        );
+
+        let elapsed = start.elapsed();
+
+        println!();
+        println!("=== Iterative Deepening Benchmark ===");
+        println!("depth reached: {}", result.depth_reached);
+        println!("best move: {:?}", result.result.best_move);
+        println!("score: {}", result.result.score);
+        println!("total nodes searched: {}", result.total_nodes);
+        println!("elapsed: {:?}", elapsed);
+
+        let ebf = (result.result.nodes_visited as f64)
+            .powf(1.0 / result.depth_reached as f64);
+
+        println!("effective branching factor: {:.2}", ebf);
     }
 }

--- a/engine/src/ai/iterative_deepening.rs
+++ b/engine/src/ai/iterative_deepening.rs
@@ -90,7 +90,11 @@ pub fn iterative_deepening(
     let mut total_nodes = 0;
     let start = Instant::now();
 
-    for depth in 1..=max_depth {
+    let start_depth = config
+        .iterative_start_depth
+        .min(max_depth);
+
+    for depth in start_depth..=max_depth {
         // Avoid starting an iteration that is
         // likely to explode exponentially.
         let elapsed = start.elapsed();

--- a/engine/src/ai/iterative_deepening.rs
+++ b/engine/src/ai/iterative_deepening.rs
@@ -9,10 +9,7 @@
 use std::time::{Duration, Instant};
 use crate::game::{ Game, Pos };
 use crate::transpose::{ TranspositionTable };
-use crate::ai::negamax;
-
-// Set max to 1 / 5 of the actual time limit
-const TIMEOUT_MS : u64 = 100;
+use crate::ai::{SearchConfig, negamax};
 
 /// What the search returns to the caller.
 #[derive(Debug, Clone)]
@@ -33,6 +30,7 @@ pub fn search_iteration(
     game: &mut Game,
     depth: u32,
     tt: &mut TranspositionTable,
+    config: &SearchConfig
 ) -> SearchIterationResult {
     let mut nodes = 0u64;
     let mut max_ply = 0;
@@ -44,7 +42,8 @@ pub fn search_iteration(
         tt,
         &mut nodes,
         &mut max_ply,
-        0
+        0,
+        config
     );
 
     SearchIterationResult {
@@ -84,6 +83,7 @@ pub fn iterative_deepening(
     game: &mut Game,
     max_depth: u32,
     tt_size: usize,
+    config: &SearchConfig,
 ) -> IterativeResult {
     let mut best = None;
     let mut tt = TranspositionTable::new(tt_size);
@@ -95,11 +95,11 @@ pub fn iterative_deepening(
         // likely to explode exponentially.
         let elapsed = start.elapsed();
 
-        if elapsed > Duration::from_millis(TIMEOUT_MS) {
+        if elapsed > Duration::from_millis(config.timeout_ms) {
             break;
         }
 
-        let result = search_iteration(game, depth, &mut tt);
+        let result = search_iteration(game, depth, &mut tt, config);
         total_nodes += result.nodes_visited;
         best = Some((depth, result));
     }
@@ -145,11 +145,13 @@ mod tests {
         let mut game = midgame_position();
 
         let before = game.clone();
+        let config = SearchConfig::default();
 
         iterative_deepening(
             &mut game,
             5,
             20,
+            &config
         );
 
         assert_eq!(game.hash(), before.hash());
@@ -194,10 +196,12 @@ mod tests {
 
         game.play_move(3, 9).unwrap();
 
+        let config = SearchConfig::default();
         let result = iterative_deepening(
             &mut game,
             4,
             20,
+            &config
         );
 
         assert_eq!(
@@ -219,8 +223,9 @@ mod tests {
         let direct = best_move(&mut g1, depth, 20);
         let direct_time = start.elapsed();
 
+        let config = SearchConfig::default();
         let start = Instant::now();
-        let iterative = iterative_deepening(&mut g2, depth, 20);
+        let iterative = iterative_deepening(&mut g2, depth, 20, &config);
         let iterative_time = start.elapsed();
 
         println!();
@@ -254,10 +259,12 @@ mod tests {
         let mut game = midgame_position();
         let start = Instant::now();
 
+        let config = SearchConfig::default();
         let result = iterative_deepening(
             &mut game,
             20,
             20,
+            &config
         );
 
         let elapsed = start.elapsed();

--- a/engine/src/ai/iterative_deepening.rs
+++ b/engine/src/ai/iterative_deepening.rs
@@ -100,7 +100,6 @@ pub fn iterative_deepening(
         }
 
         let result = search_iteration(game, depth, &mut tt);
-        println!("i: {}, nodes: {}", depth, result.nodes_visited);
         total_nodes += result.nodes_visited;
         best = Some((depth, result));
     }

--- a/engine/src/ai/mod.rs
+++ b/engine/src/ai/mod.rs
@@ -19,4 +19,4 @@ pub mod iterative_deepening;
 #[allow(unused_imports)]
 pub use eval::evaluate;
 #[allow(unused_imports)]
-pub use search::{best_move, SearchResult};
+pub use search::{negamax, best_move, SearchResult};

--- a/engine/src/ai/mod.rs
+++ b/engine/src/ai/mod.rs
@@ -11,11 +11,13 @@
 //! - [`best_move`] runs the search and returns the chosen move + score.
 //! - [`evaluate`] if you want the leaf score for a position directly.
 
+pub mod config;
 pub mod eval;
 pub mod search;
 pub mod move_ordering;
 pub mod iterative_deepening;
 
+pub use config::SearchConfig;
 #[allow(unused_imports)]
 pub use eval::evaluate;
 #[allow(unused_imports)]

--- a/engine/src/ai/search.rs
+++ b/engine/src/ai/search.rs
@@ -23,6 +23,7 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use crate::ai::SearchConfig;
 use crate::ai::eval::evaluate;
 use crate::ai::iterative_deepening::iterative_deepening;
 use crate::ai::move_ordering::order_moves;
@@ -94,7 +95,8 @@ pub fn negamax(
     tt: &mut TranspositionTable,
     nodes: &mut u64,
     max_ply: &mut u32,
-    ply: u32
+    ply: u32,
+    config: &SearchConfig
 ) -> (i32, Option<Pos>) {
     *nodes += 1;
     *max_ply = (*max_ply).max(ply);
@@ -155,7 +157,9 @@ pub fn negamax(
         }
 
         let reduction =
-            if depth >= 6 && i >= 3 {
+            if !config.enable_lmr {
+                0
+            } else if depth >= 6 && i >= 3 {
                 2
             } else if depth >= 3 && i >= 3 {
                 1
@@ -173,7 +177,8 @@ pub fn negamax(
             tt,
             nodes,
             max_ply,
-            ply + 1
+            ply + 1,
+            config
         );
 
         let mut score = -child_score;
@@ -189,7 +194,8 @@ pub fn negamax(
                     tt,
                     nodes,
                     max_ply,
-                    ply + 1
+                    ply + 1,
+                    config
                 );
 
             score = -full_score;
@@ -265,7 +271,9 @@ pub fn best_move(game: &mut Game, depth: u32, tt_size: usize) -> SearchResult {
         };
     }
 
-    let res = iterative_deepening(game, depth, tt_size);
+    let config = SearchConfig::default();
+
+    let res = iterative_deepening(game, depth, tt_size, &config);
     SearchResult {
         best_move: res.result.best_move,
         score: res.result.score,

--- a/engine/src/ai/search.rs
+++ b/engine/src/ai/search.rs
@@ -24,6 +24,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::ai::eval::evaluate;
+use crate::ai::iterative_deepening::iterative_deepening;
 use crate::ai::move_ordering::order_moves;
 use crate::constants::BOARD_SIZE;
 use crate::game::{Game, GameStatus, Pos};
@@ -34,14 +35,21 @@ use crate::transpose::{Bound, TTEntry, TranspositionTable};
 pub const WIN_SCORE: i32 = 1_000_000;
 
 /// What the search returns to the caller.
-#[derive(Debug, Clone)]
 pub struct SearchResult {
-    /// The chosen move, or `None` at depth 0 / when no legal moves exist.
+    /// Final chosen move.
     pub best_move: Option<Pos>,
-    /// Score from the root side-to-move's perspective.
+
+    /// Final evaluation score.
     pub score: i32,
-    /// Total nodes (including leaves) visited during the search.
-    pub nodes_visited: u64,
+
+    /// Deepest fully completed iterative depth.
+    pub depth_reached: u32,
+
+    /// Total nodes searched across all iterations.
+    pub total_nodes: u64,
+
+    /// Deepest ply explored overall.
+    pub max_ply: u32,
 }
 
 /// If the position is terminal, return its score from the side-to-move's
@@ -77,15 +85,19 @@ fn terminal_score(game: &Game, depth: u32) -> Option<i32> {
 /// pruning and ordering.
 ///
 /// Returns `(score, best_move_at_this_node)`.
-fn negamax(
+#[allow(clippy::too_many_arguments)]
+pub fn negamax(
     game: &mut Game,
     depth: u32,
     mut alpha: i32,
     mut beta: i32,
     tt: &mut TranspositionTable,
     nodes: &mut u64,
+    max_ply: &mut u32,
+    ply: u32
 ) -> (i32, Option<Pos>) {
     *nodes += 1;
+    *max_ply = (*max_ply).max(ply);
 
     // Look in the transposition table, if the board has been generated
     let original_alpha = alpha;
@@ -159,7 +171,9 @@ fn negamax(
             -beta,
             -alpha,
             tt,
-            nodes
+            nodes,
+            max_ply,
+            ply + 1
         );
 
         let mut score = -child_score;
@@ -174,6 +188,8 @@ fn negamax(
                     -alpha,
                     tt,
                     nodes,
+                    max_ply,
+                    ply + 1
                 );
 
             score = -full_score;
@@ -213,29 +229,6 @@ fn negamax(
     (best_score, best_mv)
 }
 
-pub fn best_move_with_tt(
-    game: &mut Game,
-    depth: u32,
-    tt: &mut TranspositionTable,
-) -> SearchResult {
-    let mut nodes = 0u64;
-
-    let (score, mv) = negamax(
-        game,
-        depth,
-        i32::MIN + 1,
-        i32::MAX - 1,
-        tt,
-        &mut nodes,
-    );
-
-    SearchResult {
-        best_move: mv,
-        score,
-        nodes_visited: nodes,
-    }
-}
-
 /// Run alpha-beta and return the best move + score.
 ///
 /// The game is left untouched (every played move is undone).
@@ -256,17 +249,30 @@ pub fn best_move(game: &mut Game, depth: u32, tt_size: usize) -> SearchResult {
         return SearchResult {
             best_move: Some(random_central_opening()),
             score: 0,
-            nodes_visited: 0,
+            depth_reached: 0,
+            total_nodes: 0,
+            max_ply: 0
         };
     }
 
-    let mut tt = TranspositionTable::new(tt_size);
+    if depth == 0 {
+        return SearchResult {
+            best_move: None,
+            score: evaluate(game),
+            depth_reached: 0,
+            total_nodes: 1,
+            max_ply: 0,
+        };
+    }
 
-    best_move_with_tt(
-        game,
-        depth,
-        &mut tt,
-    )
+    let res = iterative_deepening(game, depth, tt_size);
+    SearchResult {
+        best_move: res.result.best_move,
+        score: res.result.score,
+        depth_reached: res.depth_reached,
+        total_nodes: res.total_nodes,
+        max_ply: res.result.max_ply
+    }
 }
 
 /// Pick a Pos uniformly from the 3×3 block centred on the board centre.
@@ -307,7 +313,7 @@ mod tests {
 
         let result = best_move(&mut game, 0, 0);
         assert_eq!(result.best_move, None);
-        assert_eq!(result.nodes_visited, 1);
+        assert_eq!(result.total_nodes, 1);
     }
 
     #[test]
@@ -323,7 +329,7 @@ mod tests {
         let dx = (x as isize - centre).abs();
         let dy = (y as isize - centre).abs();
         assert!(dx <= 1 && dy <= 1, "opening {:?} must be within the central 3x3", (x, y));
-        assert_eq!(result.nodes_visited, 0, "empty-board opening should bypass search");
+        assert_eq!(result.total_nodes, 0, "empty-board opening should bypass search");
     }
 
     #[test]
@@ -373,8 +379,8 @@ mod tests {
         assert_eq!(r1.best_move, r2.best_move, "best move differs");
         assert_eq!(r1.score, r2.score, "score differs");
         assert_eq!(
-            r1.nodes_visited,
-            r2.nodes_visited,
+            r1.total_nodes,
+            r2.total_nodes,
             "node count differs"
         );
     }
@@ -451,10 +457,10 @@ mod tests {
         let r1 = best_move(&mut g1, 6, 0);
         let r2 = best_move(&mut g2, 6, 20);
 
-        println!("no TT nodes: {}", r1.nodes_visited);
-        println!("TT nodes: {}", r2.nodes_visited);
+        println!("no TT nodes: {}", r1.total_nodes);
+        println!("TT nodes: {}", r2.total_nodes);
 
-        assert!(r2.nodes_visited < r1.nodes_visited);
+        assert!(r2.total_nodes < r1.total_nodes);
     }
 
     #[test]
@@ -471,10 +477,10 @@ mod tests {
         assert_eq!(r1.best_move, r2.best_move, "best move differs with TT");
         assert_eq!(r1.score, r2.score, "score differs with TT");
 
-        println!("no TT nodes: {}", r1.nodes_visited);
-        println!("TT nodes: {}", r2.nodes_visited);
+        println!("no TT nodes: {}", r1.total_nodes);
+        println!("TT nodes: {}", r2.total_nodes);
 
-        assert!(r2.nodes_visited < r1.nodes_visited);
+        assert!(r2.total_nodes < r1.total_nodes);
     }
 
     #[test]
@@ -496,8 +502,15 @@ mod tests {
         println!();
         println!("=== Depth 10 Benchmark ===");
         println!("best move: {:?}", result.best_move);
+        println!("depth reached: {}", result.depth_reached);
+        println!("max_ply: {}", result.max_ply);
         println!("score: {}", result.score);
-        println!("nodes: {}", result.nodes_visited);
+        println!("total_nodes: {}", result.total_nodes);
         println!("time: {:?}", elapsed);
+
+        let ebf = (result.total_nodes as f64)
+            .powf(1.0 / result.depth_reached as f64);
+
+        println!("effective branching factor: {:.2}", ebf);
     }
 }

--- a/engine/src/ai/search.rs
+++ b/engine/src/ai/search.rs
@@ -135,15 +135,49 @@ fn negamax(
     let mut best_score = i32::MIN + 1;
     let mut best_mv: Option<Pos> = None;
 
-    for mv in ordered_moves {
+    for (i, mv) in ordered_moves.into_iter().enumerate() {
         // generate_moves already filters illegal placements, but play_move
         // is still the source of truth — skip defensively if it rejects.
         if game.play_pos(mv).is_err() {
             continue;
         }
 
-        let (child_score, _) = negamax(game, depth - 1, -beta, -alpha, tt, nodes);
-        let score = -child_score;
+        let reduction =
+            if depth >= 6 && i >= 3 {
+                2
+            } else if depth >= 3 && i >= 3 {
+                1
+            } else {
+                0
+            };
+
+        let search_depth = depth - 1 - reduction;
+
+        let (child_score, _) = negamax(
+            game,
+            search_depth,
+            -beta,
+            -alpha,
+            tt,
+            nodes
+        );
+
+        let mut score = -child_score;
+
+        // Re-search surprising reduced moves.
+        if reduction > 0 && score > alpha {
+            let (full_score, _) =
+                negamax(
+                    game,
+                    depth - 1,
+                    -beta,
+                    -alpha,
+                    tt,
+                    nodes,
+                );
+
+            score = -full_score;
+        }
 
         game.undo_move().expect("undo_move must succeed after a successful play_move");
 
@@ -441,5 +475,29 @@ mod tests {
         println!("TT nodes: {}", r2.nodes_visited);
 
         assert!(r2.nodes_visited < r1.nodes_visited);
+    }
+
+    #[test]
+    fn depth_10_benchmark() {
+        use std::time::Instant;
+
+        let mut game = midgame_position();
+
+        let start = Instant::now();
+
+        let result = best_move(
+            &mut game,
+            10,
+            20,
+        );
+
+        let elapsed = start.elapsed();
+
+        println!();
+        println!("=== Depth 10 Benchmark ===");
+        println!("best move: {:?}", result.best_move);
+        println!("score: {}", result.score);
+        println!("nodes: {}", result.nodes_visited);
+        println!("time: {:?}", elapsed);
     }
 }


### PR DESCRIPTION
## Summary

Add Late Move Reductions (LMR) to reduce search depth for lower-priority moves.

This PR also refactors the search pipeline around iterative deepening and configurable search settings.

## Changes

- add Late Move Reductions (LMR)
- re-search reduced moves on fail-high
- add configurable `SearchConfig`
- make LMR optional for benchmarking/debugging
- integrate iterative deepening into `best_move`
- refactor fixed-depth search into `search_iteration`
- add max ply tracking and iterative benchmarks
- improve search naming and documentation

Closes #62
Closes #65 
Closes #66