### PR TITLE
[EXPERIMENT] Root-level multithread distribution

### DIFF
--- a/engine/src/ai/config.rs
+++ b/engine/src/ai/config.rs
@@ -1,4 +1,5 @@
 /// Runtime configuration for search heuristics and limits.
+#[derive(Clone, Copy)]
 pub struct SearchConfig {
     /// Enable Late Move Reductions during search.
     pub enable_lmr: bool,

--- a/engine/src/ai/iterative_deepening.rs
+++ b/engine/src/ai/iterative_deepening.rs
@@ -7,9 +7,12 @@
 //! TT reuse, reducing the explored search tree and improving pruning
 //! efficiency at larger depths.
 use std::time::{Duration, Instant};
+use std::sync::{Arc, RwLock};
 use crate::game::{ Game, Pos };
 use crate::transpose::{ TranspositionTable };
 use crate::ai::{SearchConfig, negamax};
+use crate::ai::eval::evaluate;
+use crate::ai::move_ordering::order_moves;
 
 /// What the search returns to the caller.
 #[derive(Debug, Clone)]
@@ -29,7 +32,8 @@ pub struct SearchIterationResult {
 pub fn search_iteration(
     game: &mut Game,
     depth: u32,
-    tt: &mut TranspositionTable,
+    // tt: &mut TranspositionTable,
+    tt_handle: &Arc<RwLock<TranspositionTable>>,
     config: &SearchConfig
 ) -> SearchIterationResult {
     let mut nodes = 0u64;
@@ -39,7 +43,7 @@ pub fn search_iteration(
         depth,
         i32::MIN + 1,
         i32::MAX - 1,
-        tt,
+        tt_handle,
         &mut nodes,
         &mut max_ply,
         0,
@@ -51,6 +55,108 @@ pub fn search_iteration(
         score,
         nodes_visited: nodes,
         max_ply
+    }
+}
+
+pub fn root_distribution(
+    game: &mut Game,
+    depth: u32,
+    shared_tt: Arc<RwLock<TranspositionTable>>,
+    config: &SearchConfig,
+) -> SearchIterationResult {
+    let moves = game.generate_moves();
+
+    if moves.is_empty() {
+        return SearchIterationResult {
+            best_move: None,
+            score: evaluate(game),
+            nodes_visited: 0,
+            max_ply: 0,
+        };
+    }
+
+    let ordered_moves =
+        order_moves(
+            game,
+            moves,
+            None,
+        );
+
+    let mut handles = Vec::new();
+
+    for mv in ordered_moves {
+        let mut cloned =
+            game.clone();
+
+        if cloned.play_pos(mv).is_err() {
+            continue;
+        }
+
+        let shared_tt =
+            Arc::clone(&shared_tt);
+
+        let config =
+            config.clone();
+
+        handles.push(
+            std::thread::spawn(move || {
+                let mut nodes = 0u64;
+                let mut max_ply = 0;
+
+                let (child_score, _) =
+                    negamax(
+                        &mut cloned,
+                        depth - 1,
+                        i32::MIN + 1,
+                        i32::MAX - 1,
+                        &shared_tt,
+                        &mut nodes,
+                        &mut max_ply,
+                        1,
+                        &config,
+                    );
+
+                (
+                    mv,
+                    -child_score,
+                    nodes,
+                    max_ply,
+                )
+            })
+        );
+    }
+
+    let mut best_score =
+        i32::MIN + 1;
+
+    let mut best_move = None;
+
+    let mut total_nodes = 0;
+    let mut deepest_ply = 0;
+
+    for handle in handles {
+        let (
+            mv,
+            score,
+            nodes,
+            max_ply,
+        ) = handle.join().unwrap();
+
+        total_nodes += nodes;
+        deepest_ply =
+            deepest_ply.max(max_ply);
+
+        if score > best_score {
+            best_score = score;
+            best_move = Some(mv);
+        }
+    }
+
+    SearchIterationResult {
+        best_move,
+        score: best_score,
+        nodes_visited: total_nodes,
+        max_ply: deepest_ply,
     }
 }
 
@@ -86,7 +192,10 @@ pub fn iterative_deepening(
     config: &SearchConfig,
 ) -> IterativeResult {
     let mut best = None;
-    let mut tt = TranspositionTable::new(tt_size);
+    let tt = Arc::new(RwLock::new(
+        TranspositionTable::new(tt_size),
+    ));
+    // let mut tt = TranspositionTable::new(tt_size);
     let mut total_nodes = 0;
     let start = Instant::now();
 
@@ -103,7 +212,7 @@ pub fn iterative_deepening(
             break;
         }
 
-        let result = search_iteration(game, depth, &mut tt, config);
+        let result = root_distribution(game, depth, Arc::clone(&tt), config);
         total_nodes += result.nodes_visited;
         best = Some((depth, result));
     }

--- a/engine/src/ai/search.rs
+++ b/engine/src/ai/search.rs
@@ -21,6 +21,7 @@
 
 #![allow(dead_code)]
 
+use std::sync::{Arc, RwLock};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::ai::SearchConfig;
@@ -92,7 +93,8 @@ pub fn negamax(
     depth: u32,
     mut alpha: i32,
     mut beta: i32,
-    tt: &mut TranspositionTable,
+    // tt: &mut TranspositionTable,
+    tt_handle: &Arc<RwLock<TranspositionTable>>,
     nodes: &mut u64,
     max_ply: &mut u32,
     ply: u32,
@@ -106,7 +108,10 @@ pub fn negamax(
     let original_beta = beta;
     // Probe TT before searching children. Exact scores may terminate the
     // search immediately; lower/upper bounds may tighten the search window.
-    let tt_entry = tt.get(game.hash());
+    let tt_entry = {
+        let tt = tt_handle.read().unwrap();
+        tt.get(game.hash())
+    };
     if let Some(entry) = tt_entry {
         if entry.depth >= depth as i32 {
             match entry.flag {
@@ -174,7 +179,7 @@ pub fn negamax(
             search_depth,
             -beta,
             -alpha,
-            tt,
+            tt_handle,
             nodes,
             max_ply,
             ply + 1,
@@ -191,7 +196,7 @@ pub fn negamax(
                     depth - 1,
                     -beta,
                     -alpha,
-                    tt,
+                    tt_handle,
                     nodes,
                     max_ply,
                     ply + 1,
@@ -224,13 +229,17 @@ pub fn negamax(
         Bound::Exact
     };
 
-    tt.insert(game.hash(), TTEntry {
-        key: game.hash(),
-        depth: depth as i32,
-        score: best_score,
-        flag,
-        best_move: best_mv,
-    });
+    {
+        let mut tt_guard = tt_handle.write().unwrap();
+
+        tt_guard.insert(game.hash(), TTEntry {
+            key: game.hash(),
+            depth: depth as i32,
+            score: best_score,
+            flag,
+            best_move: best_mv,
+        });
+    }
 
     (best_score, best_mv)
 }

--- a/engine/src/transpose.rs
+++ b/engine/src/transpose.rs
@@ -96,10 +96,10 @@ impl TranspositionTable {
     ///
     /// Returns `None` if the slot is empty or contains a different hash
     /// due to collision replacement.
-    pub fn get(&self, hash: u64) -> Option<&TTEntry> {
+    pub fn get(&self, hash: u64) -> Option<TTEntry> {
         let entry = &self.entries[(hash as usize) & self.mask];
         if entry.key == hash {
-            Some(entry)
+            Some(*entry)
         } else {
             None
         }


### PR DESCRIPTION
This PR introduces a prototype root-level multithreaded negamax search using a shared transposition table through `Arc<RwLock<TranspositionTable>>`.

The experiment did not produce good practical results due to synchronization overhead, weaker move ordering, and duplicated search work. Performance generally regressed compared to the single-threaded search.

I’ll leave this implementation as a reference for future SMP experiments and possible alternative parallel search approaches.


Before:
<img width="549" height="347" alt="image" src="https://github.com/user-attachments/assets/b072f228-4803-4ef9-a76e-4217aeb17803" />

After:
<img width="549" height="347" alt="image" src="https://github.com/user-attachments/assets/0e77a63e-570f-4401-9cab-2c5b9a632249" />
